### PR TITLE
Fix CI job: Add apt update

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Checkout submodules
         run: git submodule update --init --recursive
+      - name: Update apt cache
+        run: sudo apt-get update
       - name: Install system dependencies
         run: sudo apt-get install libudev-dev libdbus-1-dev libsodium-dev
       - name: Build


### PR DESCRIPTION
CI job was failing attempting to download an old version of a package:

```
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  libdbus-1-dev libsodium-dev libudev-dev
0 upgraded, 3 newly installed, 0 to remove and 82 not upgraded.
Need to get 397 kB of archives.
After this operation, 2018 kB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libdbus-1-dev amd64 1.14.10-4ubuntu4.1 [190 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsodium-dev amd64 1.0.18-1build3 [185 kB]
Ign:4 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libudev-dev amd64 255.4-1ubuntu8.4
Ign:4 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 libudev-dev amd64 255.4-1ubuntu8.4
Err:4 http://security.ubuntu.com/ubuntu noble-updates/main amd64 libudev-dev amd64 255.4-1ubuntu8.4
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/s/systemd/libudev-dev_255.4-1ubuntu8.4_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
Fetched 375 kB in 1s (420 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```