### PR TITLE
Fix #69: Do not unwrap when extracting data from responses

### DIFF
--- a/libwebauthn/src/lib.rs
+++ b/libwebauthn/src/lib.rs
@@ -14,9 +14,17 @@ extern crate num_derive;
 extern crate bitflags;
 
 macro_rules! unwrap_field {
-    ($field:expr) => {
-        $field.ok_or(Error::Platform(PlatformError::InvalidDeviceResponse))?
-    };
+    ($field:expr) => {{
+        if let Some(f) = $field {
+            f
+        } else {
+            tracing::error!(
+                "Device response did not contain expected field: {}",
+                stringify!($field)
+            );
+            return Err(Error::Platform(PlatformError::InvalidDeviceResponse));
+        }
+    }};
 }
 pub(crate) use unwrap_field;
 

--- a/libwebauthn/src/lib.rs
+++ b/libwebauthn/src/lib.rs
@@ -13,6 +13,13 @@ extern crate num_derive;
 #[macro_use]
 extern crate bitflags;
 
+macro_rules! unwrap_field {
+    ($field:expr) => {
+        $field.ok_or(Error::Platform(PlatformError::InvalidDeviceResponse))?
+    };
+}
+pub(crate) use unwrap_field;
+
 #[derive(Debug)]
 pub enum Transport {
     Usb,

--- a/libwebauthn/src/management/bio_enrollment.rs
+++ b/libwebauthn/src/management/bio_enrollment.rs
@@ -7,9 +7,10 @@ use crate::{
         Ctap2GetInfoResponse, Ctap2LastEnrollmentSampleStatus, Ctap2UserVerifiableRequest,
     },
     transport::{
-        error::{CtapError, Error},
+        error::{CtapError, Error, PlatformError},
         Channel,
     },
+    unwrap_field,
     webauthn::{handle_errors, user_verification, UsedPinUvAuthToken},
 };
 use async_trait::async_trait;
@@ -220,10 +221,9 @@ where
             )
         }?;
 
-        // TODO: authenticators MUST return these, but should we guard against devices that don't, instead of unwrapping here?
-        let remaining_samples = resp.remaining_samples.unwrap();
-        let template_id = resp.template_id.unwrap().clone();
-        let sample_status = resp.last_enroll_sample_status.unwrap();
+        let remaining_samples = unwrap_field!(resp.remaining_samples);
+        let template_id = unwrap_field!(resp.template_id).clone();
+        let sample_status = unwrap_field!(resp.last_enroll_sample_status);
         Ok((template_id.to_vec(), sample_status, remaining_samples))
     }
 
@@ -255,9 +255,8 @@ where
             )
         }?;
 
-        // TODO: authenticators MUST return these, but should we guard against devices that don't, instead of unwrapping here?
-        let remaining_samples = resp.remaining_samples.unwrap();
-        let sample_status = resp.last_enroll_sample_status.unwrap();
+        let remaining_samples = unwrap_field!(resp.remaining_samples);
+        let sample_status = unwrap_field!(resp.last_enroll_sample_status);
         Ok((sample_status, remaining_samples))
     }
 

--- a/libwebauthn/src/management/credential_management.rs
+++ b/libwebauthn/src/management/credential_management.rs
@@ -8,9 +8,10 @@ use crate::{
         Ctap2UserVerifiableRequest,
     },
     transport::{
-        error::{CtapError, Error},
+        error::{CtapError, Error, PlatformError},
         Channel,
     },
+    unwrap_field,
     webauthn::{handle_errors, user_verification, UsedPinUvAuthToken},
 };
 use async_trait::async_trait;
@@ -91,9 +92,8 @@ where
             )
         }?;
         let metadata = Ctap2CredentialManagementMetadata::new(
-            resp.existing_resident_credentials_count.unwrap(),
-            resp.max_possible_remaining_resident_credentials_count
-                .unwrap(),
+            unwrap_field!(resp.existing_resident_credentials_count),
+            unwrap_field!(resp.max_possible_remaining_resident_credentials_count),
         );
         Ok(metadata)
     }
@@ -122,8 +122,11 @@ where
             )
         }?;
         Ok((
-            Ctap2RPData::new(resp.rp.unwrap(), resp.rp_id_hash.unwrap().to_vec()),
-            resp.total_rps.unwrap(),
+            Ctap2RPData::new(
+                unwrap_field!(resp.rp),
+                unwrap_field!(resp.rp_id_hash).to_vec(),
+            ),
+            unwrap_field!(resp.total_rps),
         ))
     }
 
@@ -151,8 +154,8 @@ where
             )
         }?;
         Ok(Ctap2RPData::new(
-            resp.rp.unwrap(),
-            resp.rp_id_hash.unwrap().to_vec(),
+            unwrap_field!(resp.rp),
+            unwrap_field!(resp.rp_id_hash).to_vec(),
         ))
     }
 
@@ -181,13 +184,13 @@ where
             )
         }?;
         let cred = Ctap2CredentialData::new(
-            resp.user.unwrap(),
-            resp.credential_id.unwrap(),
-            resp.public_key.unwrap(),
-            resp.cred_protect.unwrap(),
+            unwrap_field!(resp.user),
+            unwrap_field!(resp.credential_id),
+            unwrap_field!(resp.public_key),
+            unwrap_field!(resp.cred_protect),
             resp.large_blob_key.map(|x| x.into_vec()),
         );
-        let total_creds = resp.total_credentials.unwrap();
+        let total_creds = unwrap_field!(resp.total_credentials);
         Ok((cred, total_creds))
     }
 
@@ -215,10 +218,10 @@ where
             )
         }?;
         let cred = Ctap2CredentialData::new(
-            resp.user.unwrap(),
-            resp.credential_id.unwrap(),
-            resp.public_key.unwrap(),
-            resp.cred_protect.unwrap(),
+            unwrap_field!(resp.user),
+            unwrap_field!(resp.credential_id),
+            unwrap_field!(resp.public_key),
+            unwrap_field!(resp.cred_protect),
             resp.large_blob_key.map(|x| x.into_vec()),
         );
         Ok(cred)

--- a/libwebauthn/src/proto/ctap2/protocol.rs
+++ b/libwebauthn/src/proto/ctap2/protocol.rs
@@ -20,6 +20,22 @@ use super::{
 
 const TIMEOUT_GET_INFO: Duration = Duration::from_millis(250);
 
+macro_rules! parse_cbor {
+    ($type:ty, $data:expr) => {{
+        match from_slice::<$type>($data) {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to parse {} from CBOR-data provided by the device. Parsing error: {:?}",
+                    stringify!($type),
+                    e
+                );
+                return Err(Error::Platform(PlatformError::InvalidDeviceResponse));
+            }
+        }
+    }};
+}
+
 #[async_trait]
 pub trait Ctap2 {
     async fn ctap2_get_info(&mut self) -> Result<Ctap2GetInfoResponse, Error>;
@@ -74,8 +90,8 @@ where
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
         };
-        let ctap_response: Ctap2GetInfoResponse =
-            from_slice(&unwrap_field!(cbor_response.data)).unwrap();
+        let data = unwrap_field!(cbor_response.data);
+        let ctap_response = parse_cbor!(Ctap2GetInfoResponse, &data);
         debug!("CTAP2 GetInfo successful");
         trace!(?ctap_response);
         Ok(ctap_response)
@@ -94,8 +110,8 @@ where
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
         };
-        let ctap_response: Ctap2MakeCredentialResponse =
-            from_slice(&unwrap_field!(cbor_response.data)).unwrap();
+        let data = unwrap_field!(cbor_response.data);
+        let ctap_response = parse_cbor!(Ctap2MakeCredentialResponse, &data);
         debug!("CTAP2 MakeCredential successful");
         trace!(?ctap_response);
         Ok(ctap_response)
@@ -114,8 +130,8 @@ where
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
         };
-        let ctap_response: Ctap2GetAssertionResponse =
-            from_slice(&unwrap_field!(cbor_response.data)).unwrap();
+        let data = unwrap_field!(cbor_response.data);
+        let ctap_response = parse_cbor!(Ctap2GetAssertionResponse, &data);
         debug!("CTAP2 GetAssertion successful");
         trace!(?ctap_response);
         Ok(ctap_response)
@@ -130,8 +146,8 @@ where
         let cbor_request = CborRequest::new(Ctap2CommandCode::AuthenticatorGetNextAssertion);
         self.cbor_send(&cbor_request, TIMEOUT_GET_INFO).await?;
         let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
-        let ctap_response: Ctap2GetAssertionResponse =
-            from_slice(&unwrap_field!(cbor_response.data)).unwrap();
+        let data = unwrap_field!(cbor_response.data);
+        let ctap_response = parse_cbor!(Ctap2GetAssertionResponse, &data);
         debug!("CTAP2 GetNextAssertion successful");
         trace!(?ctap_response);
         Ok(ctap_response)
@@ -171,7 +187,7 @@ where
             error => return Err(Error::Ctap(error)),
         };
         if let Some(data) = cbor_response.data {
-            let ctap_response: Ctap2ClientPinResponse = from_slice(&data).unwrap();
+            let ctap_response = parse_cbor!(Ctap2ClientPinResponse, &data);
             debug!("CTAP2 ClientPin successful");
             trace!(?ctap_response);
             Ok(ctap_response)
@@ -220,7 +236,7 @@ where
             error => return Err(Error::Ctap(error)),
         };
         if let Some(data) = cbor_response.data {
-            let ctap_response: Ctap2BioEnrollmentResponse = from_slice(&data).unwrap();
+            let ctap_response = parse_cbor!(Ctap2BioEnrollmentResponse, &data);
             debug!("CTAP2 BioEnrollment successful");
             trace!(?ctap_response);
             Ok(ctap_response)
@@ -246,7 +262,7 @@ where
             error => return Err(Error::Ctap(error)),
         };
         if let Some(data) = cbor_response.data {
-            let ctap_response: Ctap2CredentialManagementResponse = from_slice(&data).unwrap();
+            let ctap_response = parse_cbor!(Ctap2CredentialManagementResponse, &data);
             debug!("CTAP2 CredentialManagement successful");
             trace!(?ctap_response);
             Ok(ctap_response)

--- a/libwebauthn/src/proto/ctap2/protocol.rs
+++ b/libwebauthn/src/proto/ctap2/protocol.rs
@@ -6,8 +6,9 @@ use tracing::{debug, instrument, trace, warn};
 
 use crate::proto::ctap2::cbor::CborRequest;
 use crate::proto::ctap2::{Ctap2BioEnrollmentResponse, Ctap2CommandCode};
-use crate::transport::error::{CtapError, Error};
+use crate::transport::error::{CtapError, Error, PlatformError};
 use crate::transport::Channel;
+use crate::unwrap_field;
 
 use super::model::Ctap2ClientPinResponse;
 use super::{
@@ -73,7 +74,8 @@ where
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
         };
-        let ctap_response: Ctap2GetInfoResponse = from_slice(&cbor_response.data.unwrap()).unwrap();
+        let ctap_response: Ctap2GetInfoResponse =
+            from_slice(&unwrap_field!(cbor_response.data)).unwrap();
         debug!("CTAP2 GetInfo successful");
         trace!(?ctap_response);
         Ok(ctap_response)
@@ -93,7 +95,7 @@ where
             error => return Err(Error::Ctap(error)),
         };
         let ctap_response: Ctap2MakeCredentialResponse =
-            from_slice(&cbor_response.data.unwrap()).unwrap();
+            from_slice(&unwrap_field!(cbor_response.data)).unwrap();
         debug!("CTAP2 MakeCredential successful");
         trace!(?ctap_response);
         Ok(ctap_response)
@@ -113,7 +115,7 @@ where
             error => return Err(Error::Ctap(error)),
         };
         let ctap_response: Ctap2GetAssertionResponse =
-            from_slice(&cbor_response.data.unwrap()).unwrap();
+            from_slice(&unwrap_field!(cbor_response.data)).unwrap();
         debug!("CTAP2 GetAssertion successful");
         trace!(?ctap_response);
         Ok(ctap_response)
@@ -129,7 +131,7 @@ where
         self.cbor_send(&cbor_request, TIMEOUT_GET_INFO).await?;
         let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
         let ctap_response: Ctap2GetAssertionResponse =
-            from_slice(&cbor_response.data.unwrap()).unwrap();
+            from_slice(&unwrap_field!(cbor_response.data)).unwrap();
         debug!("CTAP2 GetNextAssertion successful");
         trace!(?ctap_response);
         Ok(ctap_response)

--- a/libwebauthn/src/transport/error.rs
+++ b/libwebauthn/src/transport/error.rs
@@ -6,6 +6,7 @@ pub enum PlatformError {
     PinTooLong,
     PinNotSupported,
     NoUvAvailable,
+    InvalidDeviceResponse,
 }
 
 impl std::error::Error for PlatformError {}


### PR DESCRIPTION
There still are a bunch of other unwraps in the code (some of which you can even see in this patch), mostly parsing either CBOR or other binary stuff in the crypto-section.

Not sure, if we want to address them here as well, and if so, how. 
For CBOR-related things, we could basically also just return the serde errors?