### PR TITLE
Fix #74: Workaround for serde-indexed not supporting serde(skip) yet

### DIFF
--- a/libwebauthn/src/proto/ctap2/model/client_pin.rs
+++ b/libwebauthn/src/proto/ctap2/model/client_pin.rs
@@ -29,10 +29,10 @@ pub struct Ctap2ClientPinRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pin_hash_encrypted: Option<ByteBuf>,
 
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing_if = "always_skip")]
     pub unused_07: (),
 
-    #[serde(skip_serializing)]
+    #[serde(skip_serializing_if = "always_skip")]
     pub unused_08: (),
 
     /// permissions (0x09)
@@ -236,4 +236,10 @@ pub struct Ctap2ClientPinResponse {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uv_retries: Option<u32>,
+}
+
+// Required by serde_indexed, as serde(skip) isn't supported yet:
+//   https://github.com/trussed-dev/serde-indexed/pull/14
+fn always_skip(_v: &()) -> bool {
+    true
 }


### PR DESCRIPTION
Fixes #74, causing an error with `change_pin_hid` with Solo2 keys. 

Unconditional skips aren't supported  by `serde-indexed` - this includes either `serde(skip_serializing)` and `serde(skip)`.

This change works around the limitation by using `skip_serializing_if` alongside a method which returns always true.

Long term fix is https://github.com/trussed-dev/serde-indexed/pull/14 (unmerged since Feb 2024) - pinged authors and contributors to see if this can be merged.