### PR TITLE
Implement HMAC secret extension

### DIFF
--- a/libwebauthn/examples/webauthn_extensions_hid.rs
+++ b/libwebauthn/examples/webauthn_extensions_hid.rs
@@ -7,7 +7,7 @@ use rand::{thread_rng, Rng};
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    GetAssertionRequest, GetAssertionRequestExtensions, MakeCredentialRequest,
+    GetAssertionRequest, GetAssertionRequestExtensions, HMACGetSecretInput, MakeCredentialRequest,
     MakeCredentialsRequestExtensions, UserVerificationRequirement,
 };
 use libwebauthn::pin::{UvProvider, StdinPromptPinProvider};
@@ -100,6 +100,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             user_verification: UserVerificationRequirement::Discouraged,
             extensions: Some(GetAssertionRequestExtensions {
                 cred_blob: Some(true),
+                hmac_secret: Some(HMACGetSecretInput {
+                    salt1: [1; 32],
+                    salt2: None,
+                }),
             }),
             timeout: TIMEOUT,
         };

--- a/libwebauthn/src/ops/u2f.rs
+++ b/libwebauthn/src/ops/u2f.rs
@@ -180,7 +180,7 @@ impl UpgradableResponse<GetAssertionResponse, SignRequest> for SignResponse {
         };
 
         // Let authenticatorGetAssertionResponse be a CBOR map with the following keys whose values are as follows: [..]
-        let upgraded_response: GetAssertionResponse = Ctap2GetAssertionResponse {
+        let response = Ctap2GetAssertionResponse {
             credential_id: Some(Ctap2PublicKeyCredentialDescriptor {
                 r#type: Ctap2PublicKeyCredentialType::PublicKey,
                 id: ByteBuf::from(request.key_handle.clone()),
@@ -195,8 +195,8 @@ impl UpgradableResponse<GetAssertionResponse, SignRequest> for SignResponse {
             unsigned_extension_outputs: None,
             enterprise_attestation: None,
             attestation_statement: None,
-        }
-        .into();
+        };
+        let upgraded_response = [response.into_assertion_output(None)].as_slice().into();
 
         trace!(?upgraded_response);
         Ok(upgraded_response)

--- a/libwebauthn/src/proto/ctap2/model/client_pin.rs
+++ b/libwebauthn/src/proto/ctap2/model/client_pin.rs
@@ -3,6 +3,8 @@ use serde_bytes::ByteBuf;
 use serde_indexed::{DeserializeIndexed, SerializeIndexed};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
+use crate::pin::{PinUvAuthProtocol, PinUvAuthProtocolOne, PinUvAuthProtocolTwo};
+
 #[derive(Debug, Clone, SerializeIndexed)]
 #[serde_indexed(offset = 1)]
 pub struct Ctap2ClientPinRequest {
@@ -210,6 +212,15 @@ bitflags! {
 pub enum Ctap2PinUvAuthProtocol {
     One = 1,
     Two = 2,
+}
+
+impl Ctap2PinUvAuthProtocol {
+    pub(crate) fn create_protocol_object(&self) -> Box<dyn PinUvAuthProtocol> {
+        match self {
+            Ctap2PinUvAuthProtocol::One => Box::new(PinUvAuthProtocolOne::new()),
+            Ctap2PinUvAuthProtocol::Two => Box::new(PinUvAuthProtocolTwo::new()),
+        }
+    }
 }
 
 #[repr(u32)]

--- a/libwebauthn/src/proto/ctap2/model/get_assertion.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_assertion.rs
@@ -1,9 +1,11 @@
 use crate::{
     fido::AuthenticatorData,
     ops::webauthn::{
-        GetAssertionRequest, GetAssertionRequestExtensions, GetAssertionResponseExtensions,
+        Assertion, Ctap2HMACGetSecretOutput, GetAssertionRequest, GetAssertionRequestExtensions,
+        GetAssertionResponseExtensions, HMACGetSecretInput,
     },
     pin::PinUvAuthProtocol,
+    transport::AuthTokenData,
 };
 
 use super::{
@@ -11,11 +13,13 @@ use super::{
     Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialUserEntity,
     Ctap2UserVerifiableRequest,
 };
+use cosey::PublicKey;
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use serde_cbor::Value;
 use serde_indexed::{DeserializeIndexed, SerializeIndexed};
 use std::collections::BTreeMap;
+use tracing::error;
 
 #[derive(Debug, Clone, Copy, Serialize, Default)]
 pub struct Ctap2GetAssertionOptions {
@@ -111,7 +115,7 @@ pub struct Ctap2GetAssertionRequest {
 
     /// extensions (0x04)
     #[serde(skip_serializing_if = "Self::skip_serializing_extensions")]
-    pub extensions: Option<GetAssertionRequestExtensions>,
+    pub extensions: Option<Ctap2GetAssertionRequestExtensions>,
 
     /// options (0x05)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -127,7 +131,9 @@ pub struct Ctap2GetAssertionRequest {
 }
 
 impl Ctap2GetAssertionRequest {
-    pub fn skip_serializing_extensions(extensions: &Option<GetAssertionRequestExtensions>) -> bool {
+    pub fn skip_serializing_extensions(
+        extensions: &Option<Ctap2GetAssertionRequestExtensions>,
+    ) -> bool {
         extensions
             .as_ref()
             .map_or(true, |extensions| extensions.skip_serializing())
@@ -140,7 +146,7 @@ impl From<&GetAssertionRequest> for Ctap2GetAssertionRequest {
             relying_party_id: op.relying_party_id.clone(),
             client_data_hash: ByteBuf::from(op.hash.clone()),
             allow: op.allow.clone(),
-            extensions: op.extensions.clone(),
+            extensions: op.extensions.as_ref().map(|x| x.clone().into()),
             options: Some(Ctap2GetAssertionOptions {
                 require_user_presence: true,
                 require_user_verification: op.user_verification.is_required(),
@@ -151,13 +157,89 @@ impl From<&GetAssertionRequest> for Ctap2GetAssertionRequest {
     }
 }
 
+#[derive(Debug, Default, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Ctap2GetAssertionRequestExtensions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cred_blob: Option<bool>,
+    // Thanks, FIDO-spec for this consistent naming scheme...
+    #[serde(rename = "hmac-secret", skip_serializing_if = "Option::is_none")]
+    pub hmac_secret: Option<CalculatedHMACGetSecretInput>,
+    // From which we calculate hmac_secret
+    #[serde(skip)]
+    pub hmac_salts: Option<HMACGetSecretInput>,
+}
+
+impl From<GetAssertionRequestExtensions> for Ctap2GetAssertionRequestExtensions {
+    fn from(other: GetAssertionRequestExtensions) -> Self {
+        Ctap2GetAssertionRequestExtensions {
+            cred_blob: other.cred_blob,
+            hmac_secret: None, // Get's calculated later
+            hmac_salts: other.hmac_secret,
+        }
+    }
+}
+
+impl Ctap2GetAssertionRequestExtensions {
+    pub fn skip_serializing(&self) -> bool {
+        self.cred_blob.is_none() && self.hmac_secret.is_none()
+    }
+
+    pub fn calculate_hmac(&mut self, auth_data: &AuthTokenData) {
+        let input = if let Some(hmac_input) = &self.hmac_salts {
+            hmac_input
+        } else {
+            return;
+        };
+        let uv_proto = auth_data.protocol_version.create_protocol_object();
+
+        let public_key = auth_data.key_agreement.clone();
+        // saltEnc(0x02): Encryption of the one or two salts (called salt1 (32 bytes) and salt2 (32 bytes)) using the shared secret as follows:
+        //     One salt case: encrypt(shared secret, salt1)
+        //     Two salt case: encrypt(shared secret, salt1 || salt2)
+        let mut salts = input.salt1.to_vec();
+        if let Some(salt2) = input.salt2 {
+            salts.extend(salt2);
+        }
+        let salt_enc = if let Ok(res) = uv_proto.encrypt(&auth_data.shared_secret, &salts) {
+            ByteBuf::from(res)
+        } else {
+            error!("Failed to encrypt HMAC salts with shared secret! Skipping HMAC");
+            return;
+        };
+
+        let salt_auth = ByteBuf::from(uv_proto.authenticate(&auth_data.shared_secret, &salt_enc));
+
+        self.hmac_secret = Some(CalculatedHMACGetSecretInput {
+            public_key,
+            salt_enc,
+            salt_auth,
+            pin_auth_proto: Some(auth_data.protocol_version as u32),
+        })
+    }
+}
+
+#[derive(Debug, Clone, SerializeIndexed)]
+#[serde_indexed(offset = 1)]
+pub struct CalculatedHMACGetSecretInput {
+    // keyAgreement(0x01): public key of platform key-agreement key.
+    pub public_key: PublicKey,
+    // saltEnc(0x02): Encryption of the one or two salts
+    pub salt_enc: ByteBuf,
+    // saltAuth(0x03): authenticate(shared secret, saltEnc)
+    pub salt_auth: ByteBuf,
+    // pinUvAuthProtocol(0x04): (optional) as selected when getting the shared secret. CTAP2.1 platforms MUST include this parameter if the value of pinUvAuthProtocol is not 1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pin_auth_proto: Option<u32>,
+}
+
 #[derive(Debug, Clone, DeserializeIndexed)]
 #[serde_indexed(offset = 1)]
 pub struct Ctap2GetAssertionResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub credential_id: Option<Ctap2PublicKeyCredentialDescriptor>,
 
-    pub authenticator_data: AuthenticatorData<GetAssertionResponseExtensions>,
+    pub authenticator_data: AuthenticatorData<Ctap2GetAssertionResponseExtensions>,
 
     pub signature: ByteBuf,
 
@@ -219,5 +301,67 @@ impl Ctap2UserVerifiableRequest for Ctap2GetAssertionRequest {
 
     fn handle_legacy_preview(&mut self, _info: &Ctap2GetInfoResponse) {
         // No-op
+    }
+}
+
+impl Ctap2GetAssertionResponse {
+    pub fn into_assertion_output(self, auth_data: Option<&AuthTokenData>) -> Assertion {
+        let authenticator_data = AuthenticatorData::<GetAssertionResponseExtensions> {
+            rp_id_hash: self.authenticator_data.rp_id_hash,
+            flags: self.authenticator_data.flags,
+            signature_count: self.authenticator_data.signature_count,
+            attested_credential: self.authenticator_data.attested_credential,
+            extensions: self
+                .authenticator_data
+                .extensions
+                .map(|x| x.into_output(auth_data)),
+        };
+        Assertion {
+            credential_id: self.credential_id,
+            authenticator_data,
+            signature: self.signature.into_vec(),
+            user: self.user,
+            credentials_count: self.credentials_count,
+            user_selected: self.user_selected,
+            large_blob_key: self.large_blob_key.map(ByteBuf::into_vec),
+            unsigned_extension_outputs: self.unsigned_extension_outputs,
+            enterprise_attestation: self.enterprise_attestation,
+            attestation_statement: self.attestation_statement,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Ctap2GetAssertionResponseExtensions {
+    // Stored credBlob
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "serde_bytes")]
+    pub cred_blob: Option<Vec<u8>>,
+
+    // Thanks, FIDO-spec for this consistent naming scheme...
+    #[serde(
+        rename = "hmac-secret",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hmac_secret: Option<Ctap2HMACGetSecretOutput>,
+}
+
+impl Ctap2GetAssertionResponseExtensions {
+    pub(crate) fn into_output(
+        self,
+        auth_data: Option<&AuthTokenData>,
+    ) -> GetAssertionResponseExtensions {
+        GetAssertionResponseExtensions {
+            cred_blob: self.cred_blob,
+            hmac_secret: self.hmac_secret.and_then(|x| {
+                if let Some(auth_data) = auth_data {
+                    let uv_proto = auth_data.protocol_version.create_protocol_object();
+                    x.decrypt_output(&auth_data.shared_secret, &uv_proto)
+                } else {
+                    None
+                }
+            }),
+        }
     }
 }

--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -11,9 +11,9 @@ use crate::proto::{
     ctap2::cbor::{CborRequest, CborResponse},
 };
 use crate::transport::error::{Error, TransportError};
+use crate::transport::AuthTokenData;
 use crate::transport::{
-    channel::ChannelStatus, device::SupportedProtocols, Channel, Ctap2AuthTokenPermission,
-    Ctap2AuthTokenStore,
+    channel::ChannelStatus, device::SupportedProtocols, Channel, Ctap2AuthTokenStore,
 };
 
 use super::known_devices::CableKnownDevice;
@@ -90,14 +90,9 @@ impl<'d> Channel for CableChannel<'d> {
 }
 
 impl<'d> Ctap2AuthTokenStore for CableChannel<'d> {
-    fn store_uv_auth_token(
-        &mut self,
-        _permission: Ctap2AuthTokenPermission,
-        _pin_uv_auth_token: &[u8],
-    ) {
-    }
+    fn store_auth_data(&mut self, _auth_token_data: AuthTokenData) {}
 
-    fn get_uv_auth_token(&self, _requested_permission: &Ctap2AuthTokenPermission) -> Option<&[u8]> {
+    fn get_auth_data(&self) -> Option<&AuthTokenData> {
         None
     }
 

--- a/libwebauthn/src/transport/channel.rs
+++ b/libwebauthn/src/transport/channel.rs
@@ -9,6 +9,7 @@ use crate::proto::{
 use crate::transport::error::Error;
 
 use async_trait::async_trait;
+use cosey::PublicKey;
 
 use super::device::SupportedProtocols;
 
@@ -34,9 +35,9 @@ pub trait Channel: Send + Sync + Display + Ctap2AuthTokenStore {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ctap2AuthTokenPermission {
-    pin_uv_auth_protocol: Ctap2PinUvAuthProtocol,
-    role: Ctap2AuthTokenPermissionRole,
-    rpid: Option<String>,
+    pub(crate) pin_uv_auth_protocol: Ctap2PinUvAuthProtocol,
+    pub(crate) role: Ctap2AuthTokenPermissionRole,
+    pub(crate) rpid: Option<String>,
 }
 
 impl Ctap2AuthTokenPermission {
@@ -63,13 +64,26 @@ impl Ctap2AuthTokenPermission {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct AuthTokenData {
+    pub shared_secret: Vec<u8>,
+    pub permission: Ctap2AuthTokenPermission,
+    pub pin_uv_auth_token: Vec<u8>,
+    pub protocol_version: Ctap2PinUvAuthProtocol,
+    pub key_agreement: PublicKey,
+}
+
 #[async_trait]
 pub trait Ctap2AuthTokenStore {
-    fn store_uv_auth_token(
-        &mut self,
-        permission: Ctap2AuthTokenPermission,
-        pin_uv_auth_token: &[u8],
-    );
-    fn get_uv_auth_token(&self, requested_permission: &Ctap2AuthTokenPermission) -> Option<&[u8]>;
+    fn store_auth_data(&mut self, auth_token_data: AuthTokenData);
+    fn get_auth_data(&self) -> Option<&AuthTokenData>;
     fn clear_uv_auth_token_store(&mut self);
+    fn get_uv_auth_token(&self, requested_permission: &Ctap2AuthTokenPermission) -> Option<&[u8]> {
+        if let Some(stored_data) = self.get_auth_data() {
+            if stored_data.permission.contains(requested_permission) {
+                return Some(&stored_data.pin_uv_auth_token);
+            }
+        }
+        None
+    }
 }

--- a/libwebauthn/src/transport/mod.rs
+++ b/libwebauthn/src/transport/mod.rs
@@ -8,7 +8,7 @@ pub mod hid;
 mod channel;
 mod transport;
 
-pub(crate) use channel::Ctap2AuthTokenPermission;
+pub(crate) use channel::{AuthTokenData, Ctap2AuthTokenPermission};
 pub use channel::{Channel, Ctap2AuthTokenStore};
 pub use device::Device;
 pub use transport::Transport;


### PR DESCRIPTION
This is working, but I'll mark it as WIP for now, as we may want to incorporate extensions-related issues in here as well.

Noteworthy things here:
- `Ctap2PinUvAuthProtocol` got a new function to create a boxed `PinUvAuthProtocol`-object out of a given protocol version, as handing around the boxed dyn-trait object is quite annoying.
- I extended what will be saved in the channel wrt to auth_token-stuff, as we need the shared_secret, the key_agreement and the used protocol version in order to be able to process the HMAC input AND output. At least, with this, I could de-duplicate `get_uv_auth_token()`. However, there is also potentially a problem here, as we currently always create a shared_secret, which we shouldn't do in the CTAP 2.0 case, see also https://github.com/mozilla/authenticator-rs/issues/341
- Extension input exists in two versions: `HMACGetSecretInput` as given by the user via `GetAssertionResponseExtensions`. This is remapped to `CalculatedHMACGetSecretInput` and `Ctap2GetAssertionRequestExtensions`, respectively. `CalculatedHMACGetSecretInput` holds both the user-input and the info we will send to the device (as we need to cache the user-input somewhere, to calculate the actual hmac-secret input when we have established a shared_secret).
- `HMACGetSecretOutput` works similarly in reverse, but I currently don't rewrap to a new struct. The resulting output will contain the encrypted message from the device and the decrypted info. The encrypted message is marked private, though.

Maybe we can work out a more generic way here, to close some of the open `[Extensions]`-issues.