### PR TITLE
Implement state update and add PresenceRequired status

### DIFF
--- a/libwebauthn/examples/authenticator_config_hid.rs
+++ b/libwebauthn/examples/authenticator_config_hid.rs
@@ -3,13 +3,15 @@ use std::fmt::Display;
 use std::time::Duration;
 
 use libwebauthn::management::AuthenticatorConfig;
-use libwebauthn::pin::{UvProvider, StdinPromptPinProvider};
+use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{Ctap2, Ctap2GetInfoResponse};
 use libwebauthn::transport::hid::list_devices;
 use libwebauthn::transport::Device;
 use libwebauthn::webauthn::Error as WebAuthnError;
+use libwebauthn::StateUpdate;
 use std::io::{self, Write};
 use text_io::read;
+use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -19,6 +21,49 @@ fn setup_logging() {
         .with_env_filter(EnvFilter::from_default_env())
         .without_time()
         .init();
+}
+
+async fn handle_updates(mut state_recv: Receiver<StateUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            StateUpdate::PresenceRequired => println!("Please touch your device!"),
+            StateUpdate::UvRetry { attempts_left } => {
+                print!("UV failed.");
+                if let Some(attempts_left) = attempts_left {
+                    print!(" You have {attempts_left} attempts left.");
+                }
+            }
+            StateUpdate::PinRequired {
+                reply_to,
+                reason,
+                attempts_left,
+            } => {
+                let mut attempts_str = String::new();
+                if let Some(attempts) = attempts_left {
+                    attempts_str = format!(". You have {attempts} attempts left!");
+                };
+
+                match reason {
+                    PinRequestReason::RelyingPartyRequest => println!("RP required a PIN."),
+                    PinRequestReason::AuthenticatorPolicy => {
+                        println!("Your device requires a PIN.")
+                    }
+                    PinRequestReason::FallbackFromUV => {
+                        println!("UV failed too often and is blocked. Falling back to PIN.")
+                    }
+                }
+                print!("PIN: Please enter the PIN for your authenticator{attempts_str}: ");
+                io::stdout().flush().unwrap();
+                let pin_raw: String = read!("{}\n");
+
+                if pin_raw.is_empty() {
+                    println!("PIN: No PIN provided, cancelling operation.");
+                } else {
+                    let _ = reply_to.send(pin_raw);
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -78,13 +123,14 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     let devices = list_devices().await.unwrap();
     println!("Devices found: {:?}", devices);
-    let pin_provider: Box<dyn UvProvider> = Box::new(StdinPromptPinProvider::new());
 
     for mut device in devices {
         println!("Selected HID authenticator: {}", &device);
-        device.wink(TIMEOUT).await?;
+        let (mut channel, state_recv) = device.channel().await?;
+        channel.wink(TIMEOUT).await?;
 
-        let mut channel = device.channel().await?;
+        tokio::spawn(handle_updates(state_recv));
+
         let info = channel.ctap2_get_info().await?;
         let options = get_supported_options(&info);
 
@@ -139,24 +185,18 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
         loop {
             let action = match options[idx] {
-                Operation::ToggleAlwaysUv => channel.toggle_always_uv(&pin_provider, TIMEOUT),
-                Operation::SetMinPinLengthRpids => channel.set_min_pin_length_rpids(
-                    min_pin_length_rpids.clone(),
-                    &pin_provider,
-                    TIMEOUT,
-                ),
+                Operation::ToggleAlwaysUv => channel.toggle_always_uv(TIMEOUT),
+                Operation::SetMinPinLengthRpids => {
+                    channel.set_min_pin_length_rpids(min_pin_length_rpids.clone(), TIMEOUT)
+                }
                 Operation::SetMinPinLength(..) => {
-                    channel.set_min_pin_length(new_pin_length, &pin_provider, TIMEOUT)
+                    channel.set_min_pin_length(new_pin_length, TIMEOUT)
                 }
                 Operation::EnableEnterpriseAttestation => {
-                    channel.enable_enterprise_attestation(&pin_provider, TIMEOUT)
+                    channel.enable_enterprise_attestation(TIMEOUT)
                 }
-                Operation::EnableForceChangePin => {
-                    channel.force_change_pin(true, &pin_provider, TIMEOUT)
-                }
-                Operation::DisableForceChangePin => {
-                    channel.force_change_pin(false, &pin_provider, TIMEOUT)
-                }
+                Operation::EnableForceChangePin => channel.force_change_pin(true, TIMEOUT),
+                Operation::DisableForceChangePin => channel.force_change_pin(false, TIMEOUT),
             };
             match action.await {
                 Ok(_) => break Ok(()),

--- a/libwebauthn/examples/bio_enrollment_hid.rs
+++ b/libwebauthn/examples/bio_enrollment_hid.rs
@@ -1,12 +1,14 @@
+use libwebauthn::StateUpdate;
 use std::error::Error;
 use std::fmt::Display;
 use std::io::{self, Write};
 use std::time::Duration;
 use text_io::read;
+use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::management::BioEnrollment;
-use libwebauthn::pin::{UvProvider, StdinPromptPinProvider};
+use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{Ctap2, Ctap2GetInfoResponse, Ctap2LastEnrollmentSampleStatus};
 use libwebauthn::transport::hid::list_devices;
 use libwebauthn::transport::Device;
@@ -19,6 +21,49 @@ fn setup_logging() {
         .with_env_filter(EnvFilter::from_default_env())
         .without_time()
         .init();
+}
+
+async fn handle_updates(mut state_recv: Receiver<StateUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            StateUpdate::PresenceRequired => println!("Please touch your device!"),
+            StateUpdate::UvRetry { attempts_left } => {
+                print!("UV failed.");
+                if let Some(attempts_left) = attempts_left {
+                    print!(" You have {attempts_left} attempts left.");
+                }
+            }
+            StateUpdate::PinRequired {
+                reply_to,
+                reason,
+                attempts_left,
+            } => {
+                let mut attempts_str = String::new();
+                if let Some(attempts) = attempts_left {
+                    attempts_str = format!(". You have {attempts} attempts left!");
+                };
+
+                match reason {
+                    PinRequestReason::RelyingPartyRequest => println!("RP required a PIN."),
+                    PinRequestReason::AuthenticatorPolicy => {
+                        println!("Your device requires a PIN.")
+                    }
+                    PinRequestReason::FallbackFromUV => {
+                        println!("UV failed too often and is blocked. Falling back to PIN.")
+                    }
+                }
+                print!("PIN: Please enter the PIN for your authenticator{attempts_str}: ");
+                io::stdout().flush().unwrap();
+                let pin_raw: String = read!("{}\n");
+
+                if pin_raw.is_empty() {
+                    println!("PIN: No PIN provided, cancelling operation.");
+                } else {
+                    let _ = reply_to.send(pin_raw);
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -103,13 +148,14 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     let devices = list_devices().await.unwrap();
     println!("Devices found: {:?}", devices);
-    let mut pin_provider: Box<dyn UvProvider> = Box::new(StdinPromptPinProvider::new());
 
     for mut device in devices {
         println!("Selected HID authenticator: {}", &device);
-        device.wink(TIMEOUT).await?;
+        let (mut channel, state_recv) = device.channel().await?;
+        channel.wink(TIMEOUT).await?;
 
-        let mut channel = device.channel().await?;
+        tokio::spawn(handle_updates(state_recv));
+
         let info = channel.ctap2_get_info().await?;
         let options = get_supported_options(&info);
 
@@ -131,15 +177,12 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                     .await
                     .map(|x| format!("{x:?}")),
                 Operation::EnumerateEnrollments => channel
-                    .get_bio_enrollments(&mut pin_provider, TIMEOUT)
+                    .get_bio_enrollments(TIMEOUT)
                     .await
                     .map(|x| format!("{x:?}")),
                 Operation::RemoveEnrollment => {
                     let enrollments = loop {
-                        match channel
-                            .get_bio_enrollments(&mut pin_provider, TIMEOUT)
-                            .await
-                        {
+                        match channel.get_bio_enrollments(TIMEOUT).await {
                             Ok(r) => break r,
                             Err(WebAuthnError::Ctap(ctap_error)) => {
                                 if ctap_error.is_retryable_user_error() {
@@ -159,7 +202,6 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                     channel
                         .remove_bio_enrollment(
                             &enrollments[idx].template_id.as_ref().unwrap(),
-                            &mut pin_provider,
                             TIMEOUT,
                         )
                         .await
@@ -167,10 +209,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                 }
                 Operation::RenameEnrollment => {
                     let enrollments = loop {
-                        match channel
-                            .get_bio_enrollments(&mut pin_provider, TIMEOUT)
-                            .await
-                        {
+                        match channel.get_bio_enrollments(TIMEOUT).await {
                             Ok(r) => break r,
                             Err(WebAuthnError::Ctap(ctap_error)) => {
                                 if ctap_error.is_retryable_user_error() {
@@ -194,36 +233,28 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                         .rename_bio_enrollment(
                             &enrollments[idx].template_id.as_ref().unwrap(),
                             &new_name,
-                            &mut pin_provider,
                             TIMEOUT,
                         )
                         .await
                         .map(|x| format!("{x:?}"))
                 }
                 Operation::AddNewEnrollment => {
-                    let (template_id, mut sample_status, mut remaining_samples) = match channel
-                        .start_new_bio_enrollment(&mut pin_provider, None, TIMEOUT)
-                        .await
-                    {
-                        Ok(r) => r,
-                        Err(WebAuthnError::Ctap(ctap_error)) => {
-                            if ctap_error.is_retryable_user_error() {
-                                println!("Oops, try again! Error: {}", ctap_error);
-                                continue;
+                    let (template_id, mut sample_status, mut remaining_samples) =
+                        match channel.start_new_bio_enrollment(None, TIMEOUT).await {
+                            Ok(r) => r,
+                            Err(WebAuthnError::Ctap(ctap_error)) => {
+                                if ctap_error.is_retryable_user_error() {
+                                    println!("Oops, try again! Error: {}", ctap_error);
+                                    continue;
+                                }
+                                break Err(WebAuthnError::Ctap(ctap_error));
                             }
-                            break Err(WebAuthnError::Ctap(ctap_error));
-                        }
-                        Err(err) => break Err(err),
-                    };
+                            Err(err) => break Err(err),
+                        };
                     while remaining_samples > 0 {
                         print_status_update(sample_status, remaining_samples);
                         (sample_status, remaining_samples) = match channel
-                            .capture_next_bio_enrollment_sample(
-                                &template_id,
-                                &mut pin_provider,
-                                None,
-                                TIMEOUT,
-                            )
+                            .capture_next_bio_enrollment_sample(&template_id, None, TIMEOUT)
                             .await
                         {
                             Ok(r) => r,

--- a/libwebauthn/examples/change_pin_hid.rs
+++ b/libwebauthn/examples/change_pin_hid.rs
@@ -1,9 +1,13 @@
 use std::error::Error;
 use std::time::Duration;
 
+use libwebauthn::{
+    pin::{PinManagement, PinRequestReason},
+    StateUpdate,
+};
+use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
-use libwebauthn::pin::{PinManagement, UvProvider, StdinPromptPinProvider};
 use libwebauthn::transport::hid::list_devices;
 use libwebauthn::transport::Device;
 use libwebauthn::webauthn::Error as WebAuthnError;
@@ -19,19 +23,60 @@ fn setup_logging() {
         .init();
 }
 
+async fn handle_updates(mut state_recv: Receiver<StateUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            StateUpdate::PresenceRequired => println!("Please touch your device!"),
+            StateUpdate::UvRetry { attempts_left } => {
+                print!("UV failed.");
+                if let Some(attempts_left) = attempts_left {
+                    print!(" You have {attempts_left} attempts left.");
+                }
+            }
+            StateUpdate::PinRequired {
+                reply_to,
+                reason,
+                attempts_left,
+            } => {
+                let mut attempts_str = String::new();
+                if let Some(attempts) = attempts_left {
+                    attempts_str = format!(". You have {attempts} attempts left!");
+                };
+
+                match reason {
+                    PinRequestReason::RelyingPartyRequest => println!("RP required a PIN."),
+                    PinRequestReason::AuthenticatorPolicy => {
+                        println!("Your device requires a PIN.")
+                    }
+                    PinRequestReason::FallbackFromUV => {
+                        println!("UV failed too often and is blocked. Falling back to PIN.")
+                    }
+                }
+                print!("PIN: Please enter the PIN for your authenticator{attempts_str}: ");
+                io::stdout().flush().unwrap();
+                let pin_raw: String = read!("{}\n");
+
+                if pin_raw.is_empty() {
+                    println!("PIN: No PIN provided, cancelling operation.");
+                } else {
+                    let _ = reply_to.send(pin_raw);
+                }
+            }
+        }
+    }
+}
+
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     setup_logging();
 
     let devices = list_devices().await.unwrap();
     println!("Devices found: {:?}", devices);
-    let pin_provider: Box<dyn UvProvider> = Box::new(StdinPromptPinProvider::new());
 
     for mut device in devices {
         println!("Selected HID authenticator: {}", &device);
-        device.wink(TIMEOUT).await?;
-
-        let mut channel = device.channel().await?;
+        let (mut channel, state_recv) = device.channel().await?;
+        channel.wink(TIMEOUT).await?;
 
         print!("PIN: Please enter the _new_ PIN: ");
         io::stdout().flush().unwrap();
@@ -42,11 +87,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             return Ok(());
         }
 
+        tokio::spawn(handle_updates(state_recv));
+
         let response = loop {
-            match channel
-                .change_pin(&pin_provider, new_pin.clone(), TIMEOUT)
-                .await
-            {
+            match channel.change_pin(new_pin.clone(), TIMEOUT).await {
                 Ok(response) => break Ok(response),
                 Err(WebAuthnError::Ctap(ctap_error)) => {
                     if ctap_error.is_retryable_user_error() {
@@ -59,7 +103,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             };
         }
         .unwrap();
-        println!("WebAuthn MakeCredential response: {:?}", response);
+        println!("WebAuthn response: {:?}", response);
     }
 
     Ok(())

--- a/libwebauthn/examples/cred_management.rs
+++ b/libwebauthn/examples/cred_management.rs
@@ -1,5 +1,5 @@
 use libwebauthn::management::CredentialManagement;
-use libwebauthn::pin::{UvProvider, StdinPromptPinProvider};
+use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
     Ctap2, Ctap2CredentialData, Ctap2PublicKeyCredentialRpEntity, Ctap2RPData,
 };
@@ -7,10 +7,12 @@ use libwebauthn::proto::CtapError;
 use libwebauthn::transport::hid::list_devices;
 use libwebauthn::transport::Device;
 use libwebauthn::webauthn::Error as WebAuthnError;
+use libwebauthn::StateUpdate;
 use std::fmt::Display;
 use std::io::{self, Write};
 use std::time::Duration;
 use text_io::read;
+use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -20,6 +22,49 @@ fn setup_logging() {
         .with_env_filter(EnvFilter::from_default_env())
         .without_time()
         .init();
+}
+
+async fn handle_updates(mut state_recv: Receiver<StateUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            StateUpdate::PresenceRequired => println!("Please touch your device!"),
+            StateUpdate::UvRetry { attempts_left } => {
+                print!("UV failed.");
+                if let Some(attempts_left) = attempts_left {
+                    print!(" You have {attempts_left} attempts left.");
+                }
+            }
+            StateUpdate::PinRequired {
+                reply_to,
+                reason,
+                attempts_left,
+            } => {
+                let mut attempts_str = String::new();
+                if let Some(attempts) = attempts_left {
+                    attempts_str = format!(". You have {attempts} attempts left!");
+                };
+
+                match reason {
+                    PinRequestReason::RelyingPartyRequest => println!("RP required a PIN."),
+                    PinRequestReason::AuthenticatorPolicy => {
+                        println!("Your device requires a PIN.")
+                    }
+                    PinRequestReason::FallbackFromUV => {
+                        println!("UV failed too often and is blocked. Falling back to PIN.")
+                    }
+                }
+                print!("PIN: Please enter the PIN for your authenticator{attempts_str}: ");
+                io::stdout().flush().unwrap();
+                let pin_raw: String = read!("{}\n");
+
+                if pin_raw.is_empty() {
+                    println!("PIN: No PIN provided, cancelling operation.");
+                } else {
+                    let _ = reply_to.send(pin_raw);
+                }
+            }
+        }
+    }
 }
 
 macro_rules! handle_retries {
@@ -54,13 +99,12 @@ fn format_credential(cred: &Ctap2CredentialData) -> String {
 
 async fn enumerate_rps<T: CredentialManagement>(
     channel: &mut T,
-    pin_provider: &mut Box<dyn UvProvider>,
 ) -> Result<Vec<Ctap2RPData>, WebAuthnError> {
-    let (rp, total_rps) = handle_retries!(channel.enumerate_rps_begin(pin_provider, TIMEOUT));
+    let (rp, total_rps) = handle_retries!(channel.enumerate_rps_begin(TIMEOUT));
     let mut rps = vec![rp];
     // Starting at 1, as we already have one from the begin-call.
     for _ in 1..total_rps {
-        let rp = handle_retries!(channel.enumerate_rps_next_rp(pin_provider, TIMEOUT));
+        let rp = handle_retries!(channel.enumerate_rps_next_rp(TIMEOUT));
         rps.push(rp);
     }
     Ok(rps)
@@ -68,15 +112,14 @@ async fn enumerate_rps<T: CredentialManagement>(
 
 async fn enumerate_credentials_for_rp<T: CredentialManagement>(
     channel: &mut T,
-    pin_provider: &mut Box<dyn UvProvider>,
     rp_id_hash: &[u8],
 ) -> Result<Vec<Ctap2CredentialData>, WebAuthnError> {
     let (credential, num_of_creds) =
-        handle_retries!(channel.enumerate_credentials_begin(pin_provider, rp_id_hash, TIMEOUT));
+        handle_retries!(channel.enumerate_credentials_begin(rp_id_hash, TIMEOUT));
     let mut credentials = vec![credential];
     // Starting at 1, as we already have one from the begin-call.
     for _ in 1..num_of_creds {
-        let credential = handle_retries!(channel.enumerate_credentials_next(pin_provider, TIMEOUT));
+        let credential = handle_retries!(channel.enumerate_credentials_next(TIMEOUT));
         credentials.push(credential);
     }
     Ok(credentials)
@@ -124,13 +167,14 @@ pub async fn main() -> Result<(), WebAuthnError> {
 
     let devices = list_devices().await.unwrap();
     println!("Devices found: {:?}", devices);
-    let mut pin_provider: Box<dyn UvProvider> = Box::new(StdinPromptPinProvider::new());
 
     for mut device in devices {
         println!("Selected HID authenticator: {}", &device);
-        device.wink(TIMEOUT).await?;
+        let (mut channel, state_recv) = device.channel().await?;
+        channel.wink(TIMEOUT).await?;
 
-        let mut channel = device.channel().await?;
+        tokio::spawn(handle_updates(state_recv));
+
         let info = channel.ctap2_get_info().await?;
 
         if !info.supports_credential_management() {
@@ -153,13 +197,13 @@ pub async fn main() -> Result<(), WebAuthnError> {
         }
 
         let idx = ask_for_user_input(options.len());
-        let metadata = handle_retries!(channel.get_credential_metadata(&mut pin_provider, TIMEOUT));
+        let metadata = handle_retries!(channel.get_credential_metadata(TIMEOUT));
         if options[idx] == Operation::GetMetadata {
             println!("Metadata: {metadata:#?}");
             return Ok(());
         }
 
-        let rps = enumerate_rps(&mut channel, &mut pin_provider).await?;
+        let rps = enumerate_rps(&mut channel).await?;
         if options[idx] == Operation::EnumerateRPs {
             println!("RPs:");
             for rp in &rps {
@@ -170,9 +214,7 @@ pub async fn main() -> Result<(), WebAuthnError> {
 
         let mut credlist = Vec::new();
         for rp in &rps {
-            let creds =
-                enumerate_credentials_for_rp(&mut channel, &mut pin_provider, &rp.rp_id_hash)
-                    .await?;
+            let creds = enumerate_credentials_for_rp(&mut channel, &rp.rp_id_hash).await?;
             for cred in creds {
                 credlist.push((rp.rp.clone(), cred));
             }
@@ -194,11 +236,7 @@ pub async fn main() -> Result<(), WebAuthnError> {
 
         if options[idx] == Operation::RemoveCredential {
             let (_, cred) = &credlist[cred_idx];
-            handle_retries!(channel.delete_credential(
-                &cred.credential_id,
-                &mut pin_provider,
-                TIMEOUT
-            ));
+            handle_retries!(channel.delete_credential(&cred.credential_id, TIMEOUT));
             println!("Done");
             return Ok(());
         }
@@ -217,12 +255,7 @@ pub async fn main() -> Result<(), WebAuthnError> {
             let (_rp, cred) = &credlist[cred_idx];
             let mut user = cred.user.clone();
             user.name = Some(name);
-            handle_retries!(channel.update_user_info(
-                &cred.credential_id,
-                &user,
-                &mut pin_provider,
-                TIMEOUT
-            ));
+            handle_retries!(channel.update_user_info(&cred.credential_id, &user, TIMEOUT));
             println!("Done");
             return Ok(());
         }

--- a/libwebauthn/examples/u2f_ble.rs
+++ b/libwebauthn/examples/u2f_ble.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 use std::time::Duration;
 
+use libwebauthn::StateUpdate;
+use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::u2f::{RegisterRequest, SignRequest};
@@ -17,6 +19,15 @@ fn setup_logging() {
         .init();
 }
 
+async fn handle_updates(mut state_recv: Receiver<StateUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            StateUpdate::PresenceRequired => println!("Please touch your device!"),
+            _ => { /* U2F doesn't use other state updates */ }
+        }
+    }
+}
+
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     setup_logging();
@@ -25,7 +36,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     println!("Found {} devices.", devices.len());
 
     for mut device in devices {
-        let mut channel = device.channel().await?;
+        let (mut channel, state_recv) = device.channel().await?;
 
         const APP_ID: &str = "https://foo.example.org";
         let challenge: &[u8] =
@@ -34,6 +45,8 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         println!("Registration request sent (timeout: {:?}).", TIMEOUT);
         let register_request =
             RegisterRequest::new_u2f_v2(&APP_ID, &challenge, vec![], TIMEOUT, false);
+
+        tokio::spawn(handle_updates(state_recv));
         let response = channel.u2f_register(&register_request).await?;
         println!("Response: {:?}", response);
 

--- a/libwebauthn/examples/u2f_hid.rs
+++ b/libwebauthn/examples/u2f_hid.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 use std::time::Duration;
 
+use libwebauthn::StateUpdate;
+use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::u2f::{RegisterRequest, SignRequest};
@@ -18,6 +20,15 @@ fn setup_logging() {
         .init();
 }
 
+async fn handle_updates(mut state_recv: Receiver<StateUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            StateUpdate::PresenceRequired => println!("Please touch your device!"),
+            _ => { /* U2F doesn't use other state updates */ }
+        }
+    }
+}
+
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     setup_logging();
@@ -27,8 +38,8 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     println!("Found {} devices.", devices.len());
     for mut device in devices {
         println!("Winking device: {}", device);
-        device.wink(TIMEOUT).await?;
-        let mut channel = device.channel().await?;
+        let (mut channel, state_recv) = device.channel().await?;
+        channel.wink(TIMEOUT).await?;
 
         const APP_ID: &str = "https://foo.example.org";
         let challenge: &[u8] =
@@ -37,6 +48,8 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         println!("Registration request sent (timeout: {:?}).", TIMEOUT);
         let register_request =
             RegisterRequest::new_u2f_v2(&APP_ID, &challenge, vec![], TIMEOUT, false);
+
+        tokio::spawn(handle_updates(state_recv));
         let response = channel.u2f_register(&register_request).await?;
         println!("Response: {:?}", response);
 

--- a/libwebauthn/examples/webauthn_cable.rs
+++ b/libwebauthn/examples/webauthn_cable.rs
@@ -1,20 +1,23 @@
 use std::error::Error;
+use std::io::{self, Write};
 use std::time::Duration;
 
-use libwebauthn::transport::cable::channel::CableChannel;
+use libwebauthn::pin::PinRequestReason;
 use libwebauthn::transport::cable::known_devices::{
     CableKnownDeviceInfoStore, EphemeralDeviceInfoStore,
 };
 use libwebauthn::transport::cable::qr_code_device::{CableQrCodeDevice, QrCodeOperationHint};
+use libwebauthn::StateUpdate;
 use qrcode::render::unicode;
 use qrcode::QrCode;
 use rand::{thread_rng, Rng};
+use text_io::read;
+use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
     GetAssertionRequest, MakeCredentialRequest, UserVerificationRequirement,
 };
-use libwebauthn::pin::{UvProvider, StdinPromptPinProvider};
 use libwebauthn::proto::ctap2::{
     Ctap2CredentialType, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
     Ctap2PublicKeyCredentialUserEntity,
@@ -29,6 +32,49 @@ fn setup_logging() {
         .with_env_filter(EnvFilter::from_default_env())
         .without_time()
         .init();
+}
+
+async fn handle_updates(mut state_recv: Receiver<StateUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            StateUpdate::PresenceRequired => println!("Please touch your device!"),
+            StateUpdate::UvRetry { attempts_left } => {
+                print!("UV failed.");
+                if let Some(attempts_left) = attempts_left {
+                    print!(" You have {attempts_left} attempts left.");
+                }
+            }
+            StateUpdate::PinRequired {
+                reply_to,
+                reason,
+                attempts_left,
+            } => {
+                let mut attempts_str = String::new();
+                if let Some(attempts) = attempts_left {
+                    attempts_str = format!(". You have {attempts} attempts left!");
+                };
+
+                match reason {
+                    PinRequestReason::RelyingPartyRequest => println!("RP required a PIN."),
+                    PinRequestReason::AuthenticatorPolicy => {
+                        println!("Your device requires a PIN.")
+                    }
+                    PinRequestReason::FallbackFromUV => {
+                        println!("UV failed too often and is blocked. Falling back to PIN.")
+                    }
+                }
+                print!("PIN: Please enter the PIN for your authenticator{attempts_str}: ");
+                io::stdout().flush().unwrap();
+                let pin_raw: String = read!("{}\n");
+
+                if pin_raw.is_empty() {
+                    println!("PIN: No PIN provided, cancelling operation.");
+                } else {
+                    let _ = reply_to.send(pin_raw);
+                }
+            }
+        }
+    }
 }
 
 #[tokio::main]
@@ -52,13 +98,13 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     println!("{}", image);
 
     // Connect to a known device
-    let mut channel: CableChannel = device.channel().await.unwrap();
+    let (mut channel, state_recv) = device.channel().await.unwrap();
     println!("Tunnel established {:?}", channel);
+
+    tokio::spawn(handle_updates(state_recv));
 
     let user_id: [u8; 32] = thread_rng().gen();
     let challenge: [u8; 32] = thread_rng().gen();
-
-    let pin_provider: Box<dyn UvProvider> = Box::new(StdinPromptPinProvider::new());
 
     // Make Credentials ceremony
     let make_credentials_request = MakeCredentialRequest {
@@ -76,7 +122,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     let response = loop {
         match channel
-            .webauthn_make_credential(&make_credentials_request, &pin_provider)
+            .webauthn_make_credential(&make_credentials_request)
             .await
         {
             Ok(response) => break Ok(response),
@@ -118,14 +164,14 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     println!("{}", image);
 
     // Connect to a known device
-    let mut channel: CableChannel = device.channel().await.unwrap();
+    println!("Tunnel established {:?}", channel);
+    let (mut channel, state_recv) = device.channel().await.unwrap();
     println!("Tunnel established {:?}", channel);
 
+    tokio::spawn(handle_updates(state_recv));
+
     let response = loop {
-        match channel
-            .webauthn_get_assertion(&get_assertion, &pin_provider)
-            .await
-        {
+        match channel.webauthn_get_assertion(&get_assertion).await {
             Ok(response) => break Ok(response),
             Err(WebAuthnError::Ctap(ctap_error)) => {
                 if ctap_error.is_retryable_user_error() {

--- a/libwebauthn/examples/webauthn_extensions_hid.rs
+++ b/libwebauthn/examples/webauthn_extensions_hid.rs
@@ -1,16 +1,20 @@
 use std::convert::TryInto;
 use std::error::Error;
+use std::io::{self, Write};
 use std::time::Duration;
 
 use ctap_types::ctap2::credential_management::CredentialProtectionPolicy;
+use libwebauthn::StateUpdate;
 use rand::{thread_rng, Rng};
+use text_io::read;
+use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
     GetAssertionRequest, GetAssertionRequestExtensions, HMACGetSecretInput, MakeCredentialRequest,
     MakeCredentialsRequestExtensions, UserVerificationRequirement,
 };
-use libwebauthn::pin::{UvProvider, StdinPromptPinProvider};
+use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
     Ctap2CredentialType, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
     Ctap2PublicKeyCredentialUserEntity,
@@ -28,6 +32,49 @@ fn setup_logging() {
         .init();
 }
 
+async fn handle_updates(mut state_recv: Receiver<StateUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            StateUpdate::PresenceRequired => println!("Please touch your device!"),
+            StateUpdate::UvRetry { attempts_left } => {
+                print!("UV failed.");
+                if let Some(attempts_left) = attempts_left {
+                    print!(" You have {attempts_left} attempts left.");
+                }
+            }
+            StateUpdate::PinRequired {
+                reply_to,
+                reason,
+                attempts_left,
+            } => {
+                let mut attempts_str = String::new();
+                if let Some(attempts) = attempts_left {
+                    attempts_str = format!(". You have {attempts} attempts left!");
+                };
+
+                match reason {
+                    PinRequestReason::RelyingPartyRequest => println!("RP required a PIN."),
+                    PinRequestReason::AuthenticatorPolicy => {
+                        println!("Your device requires a PIN.")
+                    }
+                    PinRequestReason::FallbackFromUV => {
+                        println!("UV failed too often and is blocked. Falling back to PIN.")
+                    }
+                }
+                print!("PIN: Please enter the PIN for your authenticator{attempts_str}: ");
+                io::stdout().flush().unwrap();
+                let pin_raw: String = read!("{}\n");
+
+                if pin_raw.is_empty() {
+                    println!("PIN: No PIN provided, cancelling operation.");
+                } else {
+                    let _ = reply_to.send(pin_raw);
+                }
+            }
+        }
+    }
+}
+
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     setup_logging();
@@ -37,8 +84,6 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     let user_id: [u8; 32] = thread_rng().gen();
     let challenge: [u8; 32] = thread_rng().gen();
-
-    let pin_provider: Box<dyn UvProvider> = Box::new(StdinPromptPinProvider::new());
 
     let extensions = MakeCredentialsRequestExtensions {
         cred_protect: Some(CredentialProtectionPolicy::Required),
@@ -50,9 +95,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
     for mut device in devices {
         println!("Selected HID authenticator: {}", &device);
-        device.wink(TIMEOUT).await?;
+        let (mut channel, state_recv) = device.channel().await?;
+        channel.wink(TIMEOUT).await?;
 
-        let mut channel = device.channel().await?;
+        tokio::spawn(handle_updates(state_recv));
 
         // Make Credentials ceremony
         let make_credentials_request = MakeCredentialRequest {
@@ -70,7 +116,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
         let response = loop {
             match channel
-                .webauthn_make_credential(&make_credentials_request, &pin_provider)
+                .webauthn_make_credential(&make_credentials_request)
                 .await
             {
                 Ok(response) => break Ok(response),
@@ -109,10 +155,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         };
 
         let response = loop {
-            match channel
-                .webauthn_get_assertion(&get_assertion, &pin_provider)
-                .await
-            {
+            match channel.webauthn_get_assertion(&get_assertion).await {
                 Ok(response) => break Ok(response),
                 Err(WebAuthnError::Ctap(ctap_error)) => {
                     if ctap_error.is_retryable_user_error() {

--- a/libwebauthn/examples/webauthn_hid.rs
+++ b/libwebauthn/examples/webauthn_hid.rs
@@ -1,14 +1,18 @@
 use std::convert::TryInto;
 use std::error::Error;
+use std::io::{self, Write};
 use std::time::Duration;
 
+use libwebauthn::StateUpdate;
 use rand::{thread_rng, Rng};
+use text_io::read;
+use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
     GetAssertionRequest, MakeCredentialRequest, UserVerificationRequirement,
 };
-use libwebauthn::pin::{UvProvider, StdinPromptPinProvider};
+use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
     Ctap2CredentialType, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
     Ctap2PublicKeyCredentialUserEntity,
@@ -26,6 +30,49 @@ fn setup_logging() {
         .init();
 }
 
+async fn handle_updates(mut state_recv: Receiver<StateUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            StateUpdate::PresenceRequired => println!("Please touch your device!"),
+            StateUpdate::UvRetry { attempts_left } => {
+                print!("UV failed.");
+                if let Some(attempts_left) = attempts_left {
+                    print!(" You have {attempts_left} attempts left.");
+                }
+            }
+            StateUpdate::PinRequired {
+                reply_to,
+                reason,
+                attempts_left,
+            } => {
+                let mut attempts_str = String::new();
+                if let Some(attempts) = attempts_left {
+                    attempts_str = format!(". You have {attempts} attempts left!");
+                };
+
+                match reason {
+                    PinRequestReason::RelyingPartyRequest => println!("RP required a PIN."),
+                    PinRequestReason::AuthenticatorPolicy => {
+                        println!("Your device requires a PIN.")
+                    }
+                    PinRequestReason::FallbackFromUV => {
+                        println!("UV failed too often and is blocked. Falling back to PIN.")
+                    }
+                }
+                print!("PIN: Please enter the PIN for your authenticator{attempts_str}: ");
+                io::stdout().flush().unwrap();
+                let pin_raw: String = read!("{}\n");
+
+                if pin_raw.is_empty() {
+                    println!("PIN: No PIN provided, cancelling operation.");
+                } else {
+                    let _ = reply_to.send(pin_raw);
+                }
+            }
+        }
+    }
+}
+
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn Error>> {
     setup_logging();
@@ -36,13 +83,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     let user_id: [u8; 32] = thread_rng().gen();
     let challenge: [u8; 32] = thread_rng().gen();
 
-    let pin_provider: Box<dyn UvProvider> = Box::new(StdinPromptPinProvider::new());
-
     for mut device in devices {
         println!("Selected HID authenticator: {}", &device);
-        device.wink(TIMEOUT).await?;
-
-        let mut channel = device.channel().await?;
+        let (mut channel, state_recv) = device.channel().await?;
+        channel.wink(TIMEOUT).await?;
 
         // Make Credentials ceremony
         let make_credentials_request = MakeCredentialRequest {
@@ -58,9 +102,11 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             timeout: TIMEOUT,
         };
 
+        tokio::spawn(handle_updates(state_recv));
+
         let response = loop {
             match channel
-                .webauthn_make_credential(&make_credentials_request, &pin_provider)
+                .webauthn_make_credential(&make_credentials_request)
                 .await
             {
                 Ok(response) => break Ok(response),
@@ -89,10 +135,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         };
 
         let response = loop {
-            match channel
-                .webauthn_get_assertion(&get_assertion, &pin_provider)
-                .await
-            {
+            match channel.webauthn_get_assertion(&get_assertion).await {
                 Ok(response) => break Ok(response),
                 Err(WebAuthnError::Ctap(ctap_error)) => {
                     if ctap_error.is_retryable_user_error() {

--- a/libwebauthn/src/lib.rs
+++ b/libwebauthn/src/lib.rs
@@ -6,6 +6,7 @@ pub mod proto;
 pub mod transport;
 pub mod u2f;
 pub mod webauthn;
+use tokio::sync::oneshot;
 
 #[macro_use]
 extern crate num_derive;
@@ -26,12 +27,27 @@ macro_rules! unwrap_field {
         }
     }};
 }
+use pin::PinRequestReason;
 pub(crate) use unwrap_field;
 
 #[derive(Debug)]
 pub enum Transport {
     Usb,
     Ble,
+}
+
+#[derive(Debug)]
+pub enum StateUpdate {
+    UvRetry {
+        attempts_left: Option<u32>,
+    },
+    /// Oneshot channel
+    PinRequired {
+        reply_to: oneshot::Sender<String>,
+        reason: PinRequestReason,
+        attempts_left: Option<u32>,
+    },
+    PresenceRequired,
 }
 
 pub fn available_transports() -> Vec<Transport> {

--- a/libwebauthn/src/management/authenticator_config.rs
+++ b/libwebauthn/src/management/authenticator_config.rs
@@ -5,11 +5,12 @@ use crate::webauthn::handle_errors;
 use crate::webauthn::{user_verification, UsedPinUvAuthToken};
 use crate::{
     ops::webauthn::UserVerificationRequirement,
-    pin::{PinUvAuthProtocol, UvProvider},
+    pin::PinUvAuthProtocol,
     proto::ctap2::{
         Ctap2, Ctap2AuthTokenPermissionRole, Ctap2AuthenticatorConfigCommand,
         Ctap2AuthenticatorConfigRequest, Ctap2GetInfoResponse, Ctap2UserVerifiableRequest,
     },
+    StateUpdate,
 };
 use async_trait::async_trait;
 use serde_bytes::ByteBuf;
@@ -19,36 +20,21 @@ use tracing::info;
 
 #[async_trait]
 pub trait AuthenticatorConfig {
-    async fn toggle_always_uv(
-        &mut self,
-        pin_provider: &Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<(), Error>;
+    async fn toggle_always_uv(&mut self, timeout: Duration) -> Result<(), Error>;
 
-    async fn enable_enterprise_attestation(
-        &mut self,
-        pin_provider: &Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<(), Error>;
+    async fn enable_enterprise_attestation(&mut self, timeout: Duration) -> Result<(), Error>;
 
     async fn set_min_pin_length(
         &mut self,
         new_pin_length: u64,
-        pin_provider: &Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error>;
 
-    async fn force_change_pin(
-        &mut self,
-        force: bool,
-        pin_provider: &Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<(), Error>;
+    async fn force_change_pin(&mut self, force: bool, timeout: Duration) -> Result<(), Error>;
 
     async fn set_min_pin_length_rpids(
         &mut self,
         rpids: Vec<String>,
-        pin_provider: &Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error>;
 }
@@ -58,11 +44,7 @@ impl<C> AuthenticatorConfig for C
 where
     C: Channel,
 {
-    async fn toggle_always_uv(
-        &mut self,
-        pin_provider: &Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<(), Error> {
+    async fn toggle_always_uv(&mut self, timeout: Duration) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_toggle_always_uv();
 
         loop {
@@ -70,7 +52,6 @@ where
                 self,
                 UserVerificationRequirement::Required,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -79,17 +60,12 @@ where
                 self,
                 self.ctap2_authenticator_config(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }
     }
 
-    async fn enable_enterprise_attestation(
-        &mut self,
-        pin_provider: &Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<(), Error> {
+    async fn enable_enterprise_attestation(&mut self, timeout: Duration) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_enable_enterprise_attestation();
 
         loop {
@@ -97,7 +73,6 @@ where
                 self,
                 UserVerificationRequirement::Required,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -106,7 +81,6 @@ where
                 self,
                 self.ctap2_authenticator_config(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }
@@ -115,7 +89,6 @@ where
     async fn set_min_pin_length(
         &mut self,
         new_pin_length: u64,
-        pin_provider: &Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_set_min_pin_length(new_pin_length);
@@ -125,7 +98,6 @@ where
                 self,
                 UserVerificationRequirement::Required,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -134,18 +106,12 @@ where
                 self,
                 self.ctap2_authenticator_config(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }
     }
 
-    async fn force_change_pin(
-        &mut self,
-        force: bool,
-        pin_provider: &Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<(), Error> {
+    async fn force_change_pin(&mut self, force: bool, timeout: Duration) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_force_change_pin(force);
 
         loop {
@@ -153,7 +119,6 @@ where
                 self,
                 UserVerificationRequirement::Required,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -162,7 +127,6 @@ where
                 self,
                 self.ctap2_authenticator_config(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }
@@ -171,7 +135,6 @@ where
     async fn set_min_pin_length_rpids(
         &mut self,
         rpids: Vec<String>,
-        pin_provider: &Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error> {
         let mut req = Ctap2AuthenticatorConfigRequest::new_set_min_pin_length_rpids(rpids);
@@ -180,7 +143,6 @@ where
                 self,
                 UserVerificationRequirement::Required,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -189,7 +151,6 @@ where
                 self,
                 self.ctap2_authenticator_config(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }

--- a/libwebauthn/src/management/bio_enrollment.rs
+++ b/libwebauthn/src/management/bio_enrollment.rs
@@ -1,6 +1,6 @@
 use crate::{
     ops::webauthn::UserVerificationRequirement,
-    pin::{PinUvAuthProtocol, UvProvider},
+    pin::PinUvAuthProtocol,
     proto::ctap2::{
         Ctap2, Ctap2AuthTokenPermissionRole, Ctap2BioEnrollmentFingerprintKind,
         Ctap2BioEnrollmentModality, Ctap2BioEnrollmentRequest, Ctap2BioEnrollmentTemplateId,
@@ -13,6 +13,7 @@ use crate::{
     },
     unwrap_field,
     webauthn::{handle_errors, user_verification, UsedPinUvAuthToken},
+    StateUpdate,
 };
 use async_trait::async_trait;
 use serde_bytes::ByteBuf;
@@ -32,40 +33,31 @@ pub trait BioEnrollment {
     ) -> Result<Ctap2BioEnrollmentFingerprintSensorInfo, Error>;
     async fn get_bio_enrollments(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<Vec<Ctap2BioEnrollmentTemplateId>, Error>;
     async fn remove_bio_enrollment(
         &mut self,
         template_id: &[u8],
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error>;
     async fn rename_bio_enrollment(
         &mut self,
         template_id: &[u8],
         template_friendly_name: &str,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error>;
     async fn start_new_bio_enrollment(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         enrollment_timeout: Option<Duration>,
         timeout: Duration,
     ) -> Result<(Vec<u8>, Ctap2LastEnrollmentSampleStatus, u64), Error>;
     async fn capture_next_bio_enrollment_sample(
         &mut self,
         template_id: &[u8],
-        pin_provider: &mut Box<dyn UvProvider>,
         enrollment_timeout: Option<Duration>,
         timeout: Duration,
     ) -> Result<(Ctap2LastEnrollmentSampleStatus, u64), Error>;
-    async fn cancel_current_bio_enrollment(
-        &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<(), Error>;
+    async fn cancel_current_bio_enrollment(&mut self, timeout: Duration) -> Result<(), Error>;
 }
 
 #[derive(Debug, Clone)]
@@ -109,7 +101,6 @@ where
 
     async fn get_bio_enrollments(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<Vec<Ctap2BioEnrollmentTemplateId>, Error> {
         let mut req = Ctap2BioEnrollmentRequest::new_enumerate_enrollments();
@@ -119,7 +110,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -129,7 +119,6 @@ where
                 self,
                 self.ctap2_bio_enrollment(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         };
@@ -139,7 +128,6 @@ where
     async fn remove_bio_enrollment(
         &mut self,
         template_id: &[u8],
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error> {
         let mut req = Ctap2BioEnrollmentRequest::new_remove_enrollment(template_id);
@@ -149,7 +137,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -159,7 +146,6 @@ where
                 self,
                 self.ctap2_bio_enrollment(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -173,7 +159,6 @@ where
         &mut self,
         template_id: &[u8],
         template_friendly_name: &str,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error> {
         let mut req =
@@ -183,7 +168,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -193,7 +177,6 @@ where
                 self,
                 self.ctap2_bio_enrollment(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -204,7 +187,6 @@ where
 
     async fn start_new_bio_enrollment(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         enrollment_timeout: Option<Duration>,
         timeout: Duration,
     ) -> Result<(Vec<u8>, Ctap2LastEnrollmentSampleStatus, u64), Error> {
@@ -215,7 +197,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -225,7 +206,6 @@ where
                 self,
                 self.ctap2_bio_enrollment(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -239,7 +219,6 @@ where
     async fn capture_next_bio_enrollment_sample(
         &mut self,
         template_id: &[u8],
-        pin_provider: &mut Box<dyn UvProvider>,
         enrollment_timeout: Option<Duration>,
         timeout: Duration,
     ) -> Result<(Ctap2LastEnrollmentSampleStatus, u64), Error> {
@@ -251,7 +230,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -261,7 +239,6 @@ where
                 self,
                 self.ctap2_bio_enrollment(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -271,11 +248,7 @@ where
         Ok((sample_status, remaining_samples))
     }
 
-    async fn cancel_current_bio_enrollment(
-        &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<(), Error> {
+    async fn cancel_current_bio_enrollment(&mut self, timeout: Duration) -> Result<(), Error> {
         let mut req = Ctap2BioEnrollmentRequest::new_cancel_current_enrollment();
 
         loop {
@@ -283,7 +256,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -293,7 +265,6 @@ where
                 self,
                 self.ctap2_bio_enrollment(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;

--- a/libwebauthn/src/management/credential_management.rs
+++ b/libwebauthn/src/management/credential_management.rs
@@ -1,6 +1,6 @@
 use crate::{
     ops::webauthn::UserVerificationRequirement,
-    pin::{UvProvider, PinUvAuthProtocol},
+    pin::PinUvAuthProtocol,
     proto::ctap2::{
         Ctap2, Ctap2AuthTokenPermissionRole, Ctap2ClientPinRequest, Ctap2CredentialData,
         Ctap2CredentialManagementMetadata, Ctap2CredentialManagementRequest, Ctap2GetInfoResponse,
@@ -13,6 +13,7 @@ use crate::{
     },
     unwrap_field,
     webauthn::{handle_errors, user_verification, UsedPinUvAuthToken},
+    StateUpdate,
 };
 use async_trait::async_trait;
 use serde_bytes::ByteBuf;
@@ -24,41 +25,29 @@ use tracing::info;
 pub trait CredentialManagement {
     async fn get_credential_metadata(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<Ctap2CredentialManagementMetadata, Error>;
-    async fn enumerate_rps_begin(
-        &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<(Ctap2RPData, u64), Error>;
-    async fn enumerate_rps_next_rp(
-        &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<Ctap2RPData, Error>;
+    async fn enumerate_rps_begin(&mut self, timeout: Duration)
+        -> Result<(Ctap2RPData, u64), Error>;
+    async fn enumerate_rps_next_rp(&mut self, timeout: Duration) -> Result<Ctap2RPData, Error>;
     async fn enumerate_credentials_begin(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         rpid_hash: &[u8],
         timeout: Duration,
     ) -> Result<(Ctap2CredentialData, u64), Error>;
     async fn enumerate_credentials_next(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<Ctap2CredentialData, Error>;
     async fn delete_credential(
         &mut self,
         credential_id: &Ctap2PublicKeyCredentialDescriptor,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error>;
     async fn update_user_info(
         &mut self,
         credential_id: &Ctap2PublicKeyCredentialDescriptor,
         user: &Ctap2PublicKeyCredentialUserEntity,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error>;
 }
@@ -70,7 +59,6 @@ where
 {
     async fn get_credential_metadata(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<Ctap2CredentialManagementMetadata, Error> {
         let mut req = Ctap2CredentialManagementRequest::new_get_credential_metadata();
@@ -79,7 +67,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -89,7 +76,6 @@ where
                 self,
                 self.ctap2_credential_management(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -102,7 +88,6 @@ where
 
     async fn enumerate_rps_begin(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(Ctap2RPData, u64), Error> {
         let mut req = Ctap2CredentialManagementRequest::new_enumerate_rps_begin();
@@ -111,7 +96,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -121,7 +105,6 @@ where
                 self,
                 self.ctap2_credential_management(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -134,18 +117,13 @@ where
         ))
     }
 
-    async fn enumerate_rps_next_rp(
-        &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
-        timeout: Duration,
-    ) -> Result<Ctap2RPData, Error> {
+    async fn enumerate_rps_next_rp(&mut self, timeout: Duration) -> Result<Ctap2RPData, Error> {
         let mut req = Ctap2CredentialManagementRequest::new_enumerate_rps_next_rp();
         let resp = loop {
             let uv_auth_used = user_verification(
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -155,7 +133,6 @@ where
                 self,
                 self.ctap2_credential_management(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -167,7 +144,6 @@ where
 
     async fn enumerate_credentials_begin(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         rpid_hash: &[u8],
         timeout: Duration,
     ) -> Result<(Ctap2CredentialData, u64), Error> {
@@ -177,7 +153,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -187,7 +162,6 @@ where
                 self,
                 self.ctap2_credential_management(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -204,7 +178,6 @@ where
 
     async fn enumerate_credentials_next(
         &mut self,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<Ctap2CredentialData, Error> {
         let mut req = Ctap2CredentialManagementRequest::new_enumerate_credentials_next();
@@ -213,7 +186,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -223,7 +195,6 @@ where
                 self,
                 self.ctap2_credential_management(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -240,7 +211,6 @@ where
     async fn delete_credential(
         &mut self,
         credential_id: &Ctap2PublicKeyCredentialDescriptor,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error> {
         let mut req = Ctap2CredentialManagementRequest::new_delete_credential(credential_id);
@@ -249,7 +219,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -259,7 +228,6 @@ where
                 self,
                 self.ctap2_credential_management(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;
@@ -270,7 +238,6 @@ where
         &mut self,
         credential_id: &Ctap2PublicKeyCredentialDescriptor,
         user: &Ctap2PublicKeyCredentialUserEntity,
-        pin_provider: &mut Box<dyn UvProvider>,
         timeout: Duration,
     ) -> Result<(), Error> {
         let mut req =
@@ -280,7 +247,6 @@ where
                 self,
                 UserVerificationRequirement::Preferred,
                 &mut req,
-                pin_provider,
                 timeout,
             )
             .await?;
@@ -295,7 +261,6 @@ where
                 self,
                 self.ctap2_credential_management(&req, timeout).await,
                 uv_auth_used,
-                pin_provider,
                 timeout
             )
         }?;

--- a/libwebauthn/src/pin.rs
+++ b/libwebauthn/src/pin.rs
@@ -14,7 +14,7 @@ use p256::{
 };
 use rand::{rngs::OsRng, thread_rng, Rng};
 use sha2::{Digest, Sha256};
-use tracing::{error, info, instrument, warn};
+use tracing::{error, instrument, warn};
 use x509_parser::nom::AsBytes;
 
 use crate::{
@@ -30,20 +30,11 @@ type Aes256CbcEncryptor = cbc::Encryptor<aes::Aes256>;
 type Aes256CbcDecryptor = cbc::Decryptor<aes::Aes256>;
 type HmacSha256 = hmac::Hmac<Sha256>;
 
+#[derive(Default, Debug)]
 pub struct PinUvAuthToken {
     pub rpid: Option<String>,
     pub user_verified: bool,
     pub user_present: bool,
-}
-
-impl Default for PinUvAuthToken {
-    fn default() -> Self {
-        Self {
-            rpid: None,
-            user_verified: false,
-            user_present: false,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -52,105 +43,6 @@ pub enum PinRequestReason {
     AuthenticatorPolicy,
     FallbackFromUV,
     // Passkey
-}
-
-#[async_trait]
-pub trait UvProvider: Send + Sync {
-    async fn provide_pin(
-        &self,
-        attempts_left: Option<u32>,
-        reason: PinRequestReason,
-    ) -> Option<String>;
-    /// This is for displaying attempts_left only. No direct feedback from the app expected/required.
-    async fn prompt_uv_retry(&self, attempts_left: Option<u32>);
-}
-
-#[derive(Debug, Clone)]
-pub struct StaticPinProvider {
-    pin: String,
-}
-
-impl StaticPinProvider {
-    pub fn new(pin: &str) -> Self {
-        Self {
-            pin: pin.to_owned(),
-        }
-    }
-}
-
-#[async_trait]
-impl UvProvider for StaticPinProvider {
-    async fn provide_pin(
-        &self,
-        attempts_left: Option<u32>,
-        _reason: PinRequestReason,
-    ) -> Option<String> {
-        if attempts_left.map_or(false, |no| no <= 1) {
-            warn!(
-                ?attempts_left,
-                "Refusing to provide static PIN, insufficient number of attempts left"
-            );
-            return None;
-        }
-
-        info!({ pin = %self.pin, ?attempts_left }, "Providing static PIN");
-        Some(self.pin.clone())
-    }
-
-    async fn prompt_uv_retry(&self, attempts_left: Option<u32>) {
-        if let Some(attempts) = attempts_left {
-            warn!("{attempts} UV attempts left.");
-        }
-    }
-}
-
-pub struct StdinPromptPinProvider {}
-
-impl StdinPromptPinProvider {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-#[async_trait]
-impl UvProvider for StdinPromptPinProvider {
-    async fn provide_pin(
-        &self,
-        attempts_left: Option<u32>,
-        reason: PinRequestReason,
-    ) -> Option<String> {
-        use std::io::{self, Write};
-        use text_io::read;
-
-        match reason {
-            PinRequestReason::RelyingPartyRequest => println!("RP requires a PIN."),
-            PinRequestReason::AuthenticatorPolicy => println!("Authenticator requires a PIN."),
-            PinRequestReason::FallbackFromUV => {
-                println!("Builtin UV failed. Falling back to PINs.")
-            }
-        }
-
-        if let Some(attempts_left) = attempts_left {
-            println!("PIN: {} attempts left.", attempts_left);
-        }
-        print!("PIN: Please enter the PIN for your authenticator: ");
-        io::stdout().flush().unwrap();
-        let pin_raw: String = read!("{}\n");
-
-        if pin_raw.is_empty() {
-            println!("PIN: No PIN provided, cancelling operation.");
-            return None;
-        }
-
-        return Some(pin_raw);
-    }
-
-    async fn prompt_uv_retry(&self, attempts_left: Option<u32>) {
-        println!("Please provide biometrics.");
-        if let Some(attempts) = attempts_left {
-            println!("{attempts} attempts left.");
-        }
-    }
 }
 
 pub trait PinUvAuthProtocol: Send + Sync {
@@ -474,12 +366,7 @@ pub fn hkdf_sha256(salt: Option<&[u8]>, ikm: &[u8], info: &[u8]) -> Vec<u8> {
 
 #[async_trait]
 pub trait PinManagement {
-    async fn change_pin(
-        &mut self,
-        pin_provider: &Box<dyn UvProvider>,
-        new_pin: String,
-        timeout: Duration,
-    ) -> Result<(), Error>;
+    async fn change_pin(&mut self, new_pin: String, timeout: Duration) -> Result<(), Error>;
 }
 
 #[async_trait]
@@ -487,12 +374,7 @@ impl<C> PinManagement for C
 where
     C: Channel,
 {
-    async fn change_pin(
-        &mut self,
-        pin_provider: &Box<dyn UvProvider>,
-        new_pin: String,
-        timeout: Duration,
-    ) -> Result<(), Error> {
+    async fn change_pin(&mut self, new_pin: String, timeout: Duration) -> Result<(), Error> {
         let get_info_response = self.ctap2_get_info().await?;
 
         // If the minPINLength member of the authenticatorGetInfo response is absent, then let platformMinPINLengthInCodePoints be 4.
@@ -515,7 +397,6 @@ where
                     self,
                     &get_info_response,
                     uv_proto.version(),
-                    pin_provider,
                     PinRequestReason::AuthenticatorPolicy,
                     timeout,
                 )

--- a/libwebauthn/src/proto/ctap2/model.rs
+++ b/libwebauthn/src/proto/ctap2/model.rs
@@ -200,7 +200,7 @@ pub trait Ctap2UserVerifiableRequest {
     fn handle_legacy_preview(&mut self, info: &Ctap2GetInfoResponse);
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Ctap2UserVerificationOperation {
     GetPinUvAuthTokenUsingUvWithPermissions,
     GetPinUvAuthTokenUsingPinWithPermissions,

--- a/libwebauthn/src/transport/ble/channel.rs
+++ b/libwebauthn/src/transport/ble/channel.rs
@@ -10,6 +10,7 @@ use crate::transport::ble::bluez;
 use crate::transport::channel::{AuthTokenData, Channel, ChannelStatus, Ctap2AuthTokenStore};
 use crate::transport::device::SupportedProtocols;
 use crate::transport::error::{Error, TransportError};
+use crate::StateUpdate;
 
 use super::bluez::manager::SupportedRevisions;
 use super::bluez::Connection;
@@ -17,6 +18,7 @@ use super::framing::{BleCommand, BleFrame};
 use super::BleDevice;
 
 use async_trait::async_trait;
+use tokio::sync::mpsc;
 use tracing::{debug, instrument, trace, warn, Level};
 
 #[derive(Debug)]
@@ -26,12 +28,14 @@ pub struct BleChannel<'a> {
     connection: Connection,
     revision: FidoRevision,
     auth_token_data: Option<AuthTokenData>,
+    tx: mpsc::Sender<StateUpdate>,
 }
 
 impl<'a> BleChannel<'a> {
     pub async fn new(
         device: &'a BleDevice,
         revisions: &SupportedRevisions,
+        tx: mpsc::Sender<StateUpdate>,
     ) -> Result<BleChannel<'a>, Error> {
         let revision = revisions
             .select_protocol(FidoProtocol::U2F)
@@ -45,6 +49,7 @@ impl<'a> BleChannel<'a> {
             connection,
             revision,
             auth_token_data: None,
+            tx,
         };
         bluez::notify_start(&channel.connection)
             .await
@@ -153,6 +158,10 @@ impl<'a> Channel for BleChannel<'a> {
         debug!("Received CBOR response");
         trace!(?cbor_response);
         Ok(cbor_response)
+    }
+
+    fn get_state_sender(&self) -> &mpsc::Sender<StateUpdate> {
+        &self.tx
     }
 }
 

--- a/libwebauthn/src/transport/ble/device.rs
+++ b/libwebauthn/src/transport/ble/device.rs
@@ -1,10 +1,12 @@
 use std::fmt;
 
 use async_trait::async_trait;
+use tokio::sync::mpsc;
 use tracing::{info, instrument};
 
-use crate::transport::device::{Device, SupportedProtocols};
+use crate::transport::device::Device;
 use crate::transport::error::{Error, TransportError};
+use crate::StateUpdate;
 
 use super::bluez::manager::SupportedRevisions;
 use super::bluez::{supported_fido_revisions, FidoDevice as BlueZFidoDevice};
@@ -67,17 +69,18 @@ impl fmt::Display for BleDevice {
 
 #[async_trait]
 impl<'d> Device<'d, Ble, BleChannel<'d>> for BleDevice {
-    async fn channel(&'d mut self) -> Result<BleChannel<'d>, Error> {
+    async fn channel(&'d mut self) -> Result<(BleChannel<'d>, mpsc::Receiver<StateUpdate>), Error> {
         let revisions = self.supported_revisions().await?;
-        let channel = BleChannel::new(self, &revisions).await?;
-        Ok(channel)
+        let (send, recv) = mpsc::channel(1);
+        let channel = BleChannel::new(self, &revisions, send).await?;
+        Ok((channel, recv))
     }
 
-    #[instrument(skip_all)]
-    async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error> {
-        let revisions = self.supported_revisions().await?;
-        Ok(revisions.into())
-    }
+    // #[instrument(skip_all)]
+    // async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error> {
+    //     let revisions = self.supported_revisions().await?;
+    //     Ok(revisions.into())
+    // }
 }
 
 impl BleDevice {

--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -15,6 +15,7 @@ use crate::transport::AuthTokenData;
 use crate::transport::{
     channel::ChannelStatus, device::SupportedProtocols, Channel, Ctap2AuthTokenStore,
 };
+use crate::StateUpdate;
 
 use super::known_devices::CableKnownDevice;
 use super::qr_code_device::CableQrCodeDevice;
@@ -39,6 +40,7 @@ pub struct CableChannel<'d> {
     pub(crate) handle_connection: task::JoinHandle<()>,
     pub(crate) cbor_sender: mpsc::Sender<CborRequest>,
     pub(crate) cbor_receiver: mpsc::Receiver<CborResponse>,
+    pub(crate) tx: mpsc::Sender<StateUpdate>,
 }
 
 impl Display for CableChannel<'_> {
@@ -86,6 +88,10 @@ impl<'d> Channel for CableChannel<'d> {
             .recv()
             .await
             .ok_or(Error::Transport(TransportError::TransportUnavailable))
+    }
+
+    fn get_state_sender(&self) -> &mpsc::Sender<StateUpdate> {
+        &self.tx
     }
 }
 

--- a/libwebauthn/src/transport/cable/known_devices.rs
+++ b/libwebauthn/src/transport/cable/known_devices.rs
@@ -1,10 +1,11 @@
 use std::fmt::{Debug, Display};
 
 use crate::transport::error::Error;
-use crate::transport::{device::SupportedProtocols, Device};
+use crate::transport::Device;
+use crate::StateUpdate;
 
 use async_trait::async_trait;
-use tracing::instrument;
+use tokio::sync::mpsc;
 
 use super::channel::CableChannel;
 use super::Cable;
@@ -18,20 +19,12 @@ pub trait CableKnownDeviceInfoStore: Debug + Send {
 }
 
 /// A no-op known-device store for ephemeral-only implementations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct EphemeralDeviceInfoStore {
     pub last_device_info: Option<CableKnownDeviceInfo>,
 }
 
 unsafe impl Send for EphemeralDeviceInfoStore {}
-
-impl Default for EphemeralDeviceInfoStore {
-    fn default() -> Self {
-        Self {
-            last_device_info: None,
-        }
-    }
-}
 
 #[async_trait]
 impl CableKnownDeviceInfoStore for EphemeralDeviceInfoStore {
@@ -79,14 +72,14 @@ unsafe impl<'d> Sync for CableKnownDevice<'d> {}
 
 #[async_trait]
 impl<'d> Device<'d, Cable, CableChannel<'d>> for CableKnownDevice<'d> {
-    async fn channel(&'d mut self) -> Result<CableChannel, Error> {
+    async fn channel(&'d mut self) -> Result<(CableChannel, mpsc::Receiver<StateUpdate>), Error> {
         todo!()
     }
 
-    #[instrument(skip_all)]
-    async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error> {
-        todo!()
-    }
+    // #[instrument(skip_all)]
+    // async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error> {
+    //     todo!()
+    // }
 }
 
 #[cfg(test)]

--- a/libwebauthn/src/transport/cable/qr_code_device.rs
+++ b/libwebauthn/src/transport/cable/qr_code_device.rs
@@ -9,8 +9,9 @@ use rand::RngCore;
 use serde::Serialize;
 use serde_bytes::ByteArray;
 use serde_indexed::SerializeIndexed;
+use tokio::sync::mpsc;
 use tokio::time::sleep;
-use tracing::{debug, error, instrument, trace};
+use tracing::{debug, error, trace};
 
 use super::known_devices::CableKnownDeviceInfoStore;
 use super::tunnel::{self, KNOWN_TUNNEL_DOMAINS};
@@ -18,10 +19,10 @@ use super::{channel::CableChannel, Cable};
 use crate::transport::ble::bluez::{self, FidoDevice};
 use crate::transport::cable::crypto::{derive, trial_decrypt_advert, KeyPurpose};
 use crate::transport::cable::digit_encode;
-use crate::transport::device::SupportedProtocols;
 use crate::transport::error::Error;
 use crate::transport::Device;
 use crate::webauthn::TransportError;
+use crate::StateUpdate;
 
 const CABLE_UUID_FIDO: &str = "0000fff9-0000-1000-8000-00805f9b34fb";
 const CABLE_UUID_GOOGLE: &str = "0000fde2-0000-1000-8000-00805f9b34fb";
@@ -240,7 +241,9 @@ impl Display for CableQrCodeDevice<'_> {
 
 #[async_trait]
 impl<'d> Device<'d, Cable, CableChannel<'d>> for CableQrCodeDevice<'_> {
-    async fn channel(&'d mut self) -> Result<CableChannel<'d>, Error> {
+    async fn channel(
+        &'d mut self,
+    ) -> Result<(CableChannel<'d>, mpsc::Receiver<StateUpdate>), Error> {
         let (_device, advert) = self.await_advertisement().await?;
 
         let Some(tunnel_domain) =
@@ -276,10 +279,10 @@ impl<'d> Device<'d, Cable, CableChannel<'d>> for CableQrCodeDevice<'_> {
         .await;
     }
 
-    #[instrument(skip_all)]
-    async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error> {
-        Ok(SupportedProtocols::fido2_only())
-    }
+    // #[instrument(skip_all)]
+    // async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error> {
+    //     Ok(SupportedProtocols::fido2_only())
+    // }
 }
 
 // TODO: unit tests

--- a/libwebauthn/src/transport/cable/tunnel.rs
+++ b/libwebauthn/src/transport/cable/tunnel.rs
@@ -20,6 +20,7 @@ use crate::proto::ctap2::cbor::{CborRequest, CborResponse};
 use crate::proto::ctap2::{Ctap2CommandCode, Ctap2GetInfoResponse};
 use crate::transport::error::Error;
 use crate::webauthn::TransportError;
+use crate::StateUpdate;
 
 pub(crate) const KNOWN_TUNNEL_DOMAINS: &[&str] = &["cable.ua5v.com", "cable.auth.com"];
 const SHA_INPUT: &[u8] = b"caBLEv2 tunnel server domain";
@@ -133,7 +134,7 @@ pub async fn connect<'d>(
     tunnel_id: &str,
     psk: &[u8; 32],
     private_key: &NonZeroScalar,
-) -> Result<CableChannel<'d>, Error> {
+) -> Result<(CableChannel<'d>, mpsc::Receiver<StateUpdate>), Error> {
     let connect_url = format!(
         "wss://{}/cable/connect/{}/{}",
         tunnel_domain, routing_id, tunnel_id
@@ -171,12 +172,17 @@ pub async fn connect<'d>(
 
     let (cbor_sender, cbor_receiver, handle_connection) = task_connection(ws_stream, noise_state)?;
 
-    Ok(CableChannel {
-        device: CableChannelDevice::QrCode(device),
-        handle_connection,
-        cbor_sender,
-        cbor_receiver,
-    })
+    let (send, recv) = mpsc::channel(1);
+    Ok((
+        CableChannel {
+            device: CableChannelDevice::QrCode(device),
+            handle_connection,
+            cbor_sender,
+            cbor_receiver,
+            tx: send,
+        },
+        recv,
+    ))
 }
 
 async fn do_handshake(

--- a/libwebauthn/src/transport/channel.rs
+++ b/libwebauthn/src/transport/channel.rs
@@ -1,15 +1,20 @@
 use std::fmt::{Debug, Display};
 use std::time::Duration;
 
-use crate::proto::ctap2::{Ctap2AuthTokenPermissionRole, Ctap2PinUvAuthProtocol};
+use crate::proto::ctap2::{
+    Ctap2AuthTokenPermissionRole, Ctap2PinUvAuthProtocol, Ctap2UserVerificationOperation,
+};
 use crate::proto::{
     ctap1::apdu::{ApduRequest, ApduResponse},
     ctap2::cbor::{CborRequest, CborResponse},
 };
 use crate::transport::error::Error;
+use crate::StateUpdate;
 
 use async_trait::async_trait;
 use cosey::PublicKey;
+use tokio::sync::mpsc;
+use tracing::{debug, error};
 
 use super::device::SupportedProtocols;
 
@@ -22,6 +27,17 @@ pub enum ChannelStatus {
 
 #[async_trait]
 pub trait Channel: Send + Sync + Display + Ctap2AuthTokenStore {
+    fn get_state_sender(&self) -> &mpsc::Sender<StateUpdate>;
+    async fn send_state_update(&mut self, state: StateUpdate) {
+        debug!("Sending state update: {state:?}");
+        match self.get_state_sender().send(state).await {
+            Ok(_) => (), // Success
+            Err(_) => {
+                error!("Failed to send state update. Application must have hung up. Closing.");
+                self.close().await;
+            }
+        };
+    }
     async fn supported_protocols(&self) -> Result<SupportedProtocols, Error>;
     async fn status(&self) -> ChannelStatus;
     async fn close(&mut self);
@@ -71,6 +87,7 @@ pub struct AuthTokenData {
     pub pin_uv_auth_token: Vec<u8>,
     pub protocol_version: Ctap2PinUvAuthProtocol,
     pub key_agreement: PublicKey,
+    pub uv_operation: Ctap2UserVerificationOperation,
 }
 
 #[async_trait]
@@ -85,5 +102,13 @@ pub trait Ctap2AuthTokenStore {
             }
         }
         None
+    }
+    fn used_pin_for_auth(&self) -> bool {
+        if let Some(stored_data) = self.get_auth_data() {
+            return stored_data.uv_operation
+                == Ctap2UserVerificationOperation::GetPinUvAuthTokenUsingPinWithPermissions
+                || stored_data.uv_operation == Ctap2UserVerificationOperation::GetPinToken;
+        }
+        false
     }
 }

--- a/libwebauthn/src/transport/device.rs
+++ b/libwebauthn/src/transport/device.rs
@@ -1,7 +1,8 @@
 use std::fmt::Display;
 
-use crate::fido::FidoRevision;
+use crate::{fido::FidoRevision, StateUpdate};
 use async_trait::async_trait;
+use tokio::sync::mpsc;
 
 use crate::transport::ble::bluez::manager::SupportedRevisions;
 use crate::transport::error::Error;
@@ -14,8 +15,8 @@ where
     T: Transport,
     C: Channel + 'd,
 {
-    async fn channel(&'d mut self) -> Result<C, Error>;
-    async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error>;
+    async fn channel(&'d mut self) -> Result<(C, mpsc::Receiver<StateUpdate>), Error>;
+    // async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error>;
 }
 
 #[derive(Debug, Copy, Clone, Default)]

--- a/libwebauthn/src/transport/hid/device.rs
+++ b/libwebauthn/src/transport/hid/device.rs
@@ -1,9 +1,8 @@
-use std::fmt;
-use std::time::Duration;
-
 use async_trait::async_trait;
 use hidapi::DeviceInfo;
 use hidapi::HidApi;
+use std::fmt;
+use tokio::sync::mpsc;
 #[allow(unused_imports)]
 use tracing::{debug, info, instrument};
 
@@ -13,9 +12,9 @@ use solo::SoloVirtualKey;
 use super::channel::HidChannel;
 use super::Hid;
 
-use crate::transport::device::SupportedProtocols;
 use crate::transport::error::{Error, TransportError};
-use crate::transport::{Channel, Device};
+use crate::transport::Device;
+use crate::StateUpdate;
 
 #[derive(Debug)]
 pub struct HidDevice {
@@ -69,7 +68,6 @@ pub async fn list_devices() -> Result<Vec<HidDevice>, Error> {
 pub async fn list_devices() -> Result<Vec<HidDevice>, Error> {
     let devices: Vec<_> = get_hidapi()?
         .device_list()
-        .into_iter()
         .filter(|device| device.usage_page() == 0xF1D0)
         .filter(|device| device.usage() == 0x0001)
         .map(|device| device.into())
@@ -87,25 +85,20 @@ impl HidDevice {
             backend: HidBackendDevice::VirtualDevice(solo),
         }
     }
-
-    #[instrument(skip_all, fields(dev = %self))]
-    pub async fn wink(&mut self, timeout: Duration) -> Result<bool, Error> {
-        let mut channel = self.channel().await?;
-        channel.wink(timeout).await
-    }
 }
 
 #[async_trait]
 impl<'d> Device<'d, Hid, HidChannel<'d>> for HidDevice {
-    async fn channel(&'d mut self) -> Result<HidChannel<'d>, Error> {
-        let channel = HidChannel::new(self).await?;
-        Ok(channel)
+    async fn channel(&'d mut self) -> Result<(HidChannel<'d>, mpsc::Receiver<StateUpdate>), Error> {
+        let (send, recv) = mpsc::channel(1);
+        let channel = HidChannel::new(self, send).await?;
+        Ok((channel, recv))
     }
 
-    async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error> {
-        let channel = self.channel().await?;
-        channel.supported_protocols().await
-    }
+    // async fn supported_protocols(&mut self) -> Result<SupportedProtocols, Error> {
+    //     let channel = self.channel().await?;
+    //     channel.supported_protocols().await
+    // }
 }
 
 #[cfg(test)]
@@ -119,7 +112,7 @@ mod tests {
         use crate::transport::Device;
 
         let mut device = HidDevice::new_virtual();
-        let channel = device.channel().await.unwrap();
+        let (channel, _) = device.channel().await.unwrap();
 
         let protocols = channel.supported_protocols().await.unwrap();
 

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -13,7 +13,6 @@ use crate::ops::webauthn::{
 use crate::ops::webauthn::{MakeCredentialRequest, MakeCredentialResponse};
 use crate::pin::{
     pin_hash, PinRequestReason, PinUvAuthProtocol, PinUvAuthProtocolOne, PinUvAuthProtocolTwo,
-    UvProvider,
 };
 use crate::proto::ctap1::Ctap1;
 use crate::proto::ctap2::{
@@ -23,9 +22,10 @@ use crate::proto::ctap2::{
 };
 pub use crate::transport::error::{CtapError, Error, PlatformError, TransportError};
 use crate::transport::{AuthTokenData, Channel, Ctap2AuthTokenPermission};
+use crate::StateUpdate;
 
 macro_rules! handle_errors {
-    ($channel: expr, $resp: expr, $uv_auth_used: expr, $pin_provider: expr, $timeout: expr) => {
+    ($channel: expr, $resp: expr, $uv_auth_used: expr, $timeout: expr) => {
         match $resp {
             Err(Error::Ctap(CtapError::PINAuthInvalid))
                 if $uv_auth_used == UsedPinUvAuthToken::FromStorage =>
@@ -41,7 +41,9 @@ macro_rules! handle_errors {
                     .map(|x| x.uv_retries)
                     .ok() // It's optional, so soft-error here
                     .flatten();
-                $pin_provider.prompt_uv_retry(attempts_left).await;
+                $channel
+                    .send_state_update(StateUpdate::UvRetry { attempts_left })
+                    .await;
                 break Err(Error::Ctap(CtapError::UVInvalid));
             }
             x => {
@@ -57,17 +59,14 @@ pub trait WebAuthn {
     async fn webauthn_make_credential(
         &mut self,
         op: &MakeCredentialRequest,
-        pin_provider: &Box<dyn UvProvider>,
     ) -> Result<MakeCredentialResponse, Error>;
     async fn webauthn_get_assertion(
         &mut self,
         op: &GetAssertionRequest,
-        pin_provider: &Box<dyn UvProvider>,
     ) -> Result<GetAssertionResponse, Error>;
     async fn _webauthn_make_credential_fido2(
         &mut self,
         op: &MakeCredentialRequest,
-        pin_provider: &Box<dyn UvProvider>,
     ) -> Result<MakeCredentialResponse, Error>;
     async fn _webauthn_make_credential_u2f(
         &mut self,
@@ -77,7 +76,6 @@ pub trait WebAuthn {
     async fn _webauthn_get_assertion_fido2(
         &mut self,
         op: &GetAssertionRequest,
-        pin_provider: &Box<dyn UvProvider>,
     ) -> Result<GetAssertionResponse, Error>;
     async fn _webauthn_get_assertion_u2f(
         &mut self,
@@ -98,7 +96,7 @@ pub(crate) async fn select_uv_proto(
     }
 
     error!(?get_info_response.pin_auth_protos, "No supported PIN/UV auth protocols found");
-    return Err(Error::Ctap(CtapError::Other));
+    Err(Error::Ctap(CtapError::Other))
 }
 
 #[async_trait]
@@ -110,12 +108,11 @@ where
     async fn webauthn_make_credential(
         &mut self,
         op: &MakeCredentialRequest,
-        pin_provider: &Box<dyn UvProvider>,
     ) -> Result<MakeCredentialResponse, Error> {
         trace!(?op, "WebAuthn MakeCredential request");
         let protocol = self._negotiate_protocol(op.is_downgradable()).await?;
         match protocol {
-            FidoProtocol::FIDO2 => self._webauthn_make_credential_fido2(op, pin_provider).await,
+            FidoProtocol::FIDO2 => self._webauthn_make_credential_fido2(op).await,
             FidoProtocol::U2F => self._webauthn_make_credential_u2f(op).await,
         }
     }
@@ -123,23 +120,22 @@ where
     async fn _webauthn_make_credential_fido2(
         &mut self,
         op: &MakeCredentialRequest,
-        pin_provider: &Box<dyn UvProvider>,
     ) -> Result<MakeCredentialResponse, Error> {
         let mut ctap2_request: Ctap2MakeCredentialRequest = op.into();
         loop {
-            let uv_auth_used = user_verification(
-                self,
-                op.user_verification,
-                &mut ctap2_request,
-                pin_provider,
-                op.timeout,
-            )
-            .await?;
+            let uv_auth_used =
+                user_verification(self, op.user_verification, &mut ctap2_request, op.timeout)
+                    .await?;
+
+            // We've already sent out this update, in case we used builtin UV
+            // but if we used PIN, we need to touch the device now.
+            if self.used_pin_for_auth() {
+                self.send_state_update(StateUpdate::PresenceRequired).await;
+            }
             handle_errors!(
                 self,
                 self.ctap2_make_credential(&ctap2_request, op.timeout).await,
                 uv_auth_used,
-                pin_provider,
                 op.timeout
             )
         }
@@ -150,6 +146,8 @@ where
         op: &MakeCredentialRequest,
     ) -> Result<MakeCredentialResponse, Error> {
         let register_request: RegisterRequest = op.try_downgrade()?;
+
+        self.send_state_update(StateUpdate::PresenceRequired).await;
         self.ctap1_register(&register_request)
             .await?
             .try_upgrade(op)
@@ -159,12 +157,11 @@ where
     async fn webauthn_get_assertion(
         &mut self,
         op: &GetAssertionRequest,
-        pin_provider: &Box<dyn UvProvider>,
     ) -> Result<GetAssertionResponse, Error> {
         trace!(?op, "WebAuthn GetAssertion request");
         let protocol = self._negotiate_protocol(op.is_downgradable()).await?;
         match protocol {
-            FidoProtocol::FIDO2 => self._webauthn_get_assertion_fido2(op, pin_provider).await,
+            FidoProtocol::FIDO2 => self._webauthn_get_assertion_fido2(op).await,
             FidoProtocol::U2F => self._webauthn_get_assertion_u2f(op).await,
         }
     }
@@ -172,19 +169,18 @@ where
     async fn _webauthn_get_assertion_fido2(
         &mut self,
         op: &GetAssertionRequest,
-        pin_provider: &Box<dyn UvProvider>,
     ) -> Result<GetAssertionResponse, Error> {
         let mut ctap2_request: Ctap2GetAssertionRequest = op.into();
         let response = loop {
-            let uv_auth_used = user_verification(
-                self,
-                op.user_verification,
-                &mut ctap2_request,
-                pin_provider,
-                op.timeout,
-            )
-            .await?;
+            let uv_auth_used =
+                user_verification(self, op.user_verification, &mut ctap2_request, op.timeout)
+                    .await?;
 
+            // We've already sent out this update, in case we used builtin UV
+            // but if we used PIN, we need to touch the device now.
+            if self.used_pin_for_auth() {
+                self.send_state_update(StateUpdate::PresenceRequired).await;
+            }
             if let Some(auth_data) = self.get_auth_data() {
                 if let Some(e) = ctap2_request.extensions.as_mut() {
                     e.calculate_hmac(auth_data)
@@ -195,7 +191,6 @@ where
                 self,
                 self.ctap2_get_assertion(&ctap2_request, op.timeout).await,
                 uv_auth_used,
-                pin_provider,
                 op.timeout
             )
         }?;
@@ -217,6 +212,7 @@ where
         let sign_requests: Vec<SignRequest> = op.try_downgrade()?;
 
         for sign_request in sign_requests {
+            self.send_state_update(StateUpdate::PresenceRequired).await;
             match self.ctap1_sign(&sign_request).await {
                 Ok(response) => {
                     debug!("Found successful candidate in allowList");
@@ -279,7 +275,6 @@ pub(crate) async fn user_verification<R, C>(
     channel: &mut C,
     user_verification: UserVerificationRequirement,
     ctap2_request: &mut R,
-    pin_provider: &Box<dyn UvProvider>,
     timeout: Duration,
 ) -> Result<UsedPinUvAuthToken, Error>
 where
@@ -298,14 +293,7 @@ where
         ctap2_request.calculate_and_set_uv_auth(&uv_proto, uv_auth_token);
         Ok(UsedPinUvAuthToken::FromStorage)
     } else {
-        user_verification_helper(
-            channel,
-            user_verification,
-            ctap2_request,
-            pin_provider,
-            timeout,
-        )
-        .await
+        user_verification_helper(channel, user_verification, ctap2_request, timeout).await
     }
 }
 
@@ -314,7 +302,6 @@ async fn user_verification_helper<R, C>(
     channel: &mut C,
     user_verification: UserVerificationRequirement,
     ctap2_request: &mut R,
-    pin_provider: &Box<dyn UvProvider>,
     timeout: Duration,
 ) -> Result<UsedPinUvAuthToken, Error>
 where
@@ -348,7 +335,7 @@ where
     let skip_uv = !ctap2_request.can_use_uv(&get_info_response);
 
     let mut uv_blocked = false;
-    let (uv_proto, token_response, shared_secret, public_key) = loop {
+    let (uv_proto, token_response, shared_secret, public_key, uv_operation) = loop {
         let uv_operation = get_info_response
             .uv_operation(uv_blocked || skip_uv)
             .ok_or({
@@ -384,7 +371,6 @@ where
                         channel,
                         &get_info_response,
                         uv_proto.version(),
-                        pin_provider,
                         reason,
                         timeout,
                     )
@@ -421,6 +407,9 @@ where
                 )
             }
             Ctap2UserVerificationOperation::GetPinUvAuthTokenUsingUvWithPermissions => {
+                channel
+                    .send_state_update(StateUpdate::PresenceRequired)
+                    .await;
                 Ctap2ClientPinRequest::new_get_uv_token_with_perm(
                     uv_proto.version(),
                     public_key.clone(),
@@ -432,7 +421,7 @@ where
 
         match channel.ctap2_client_pin(&token_request, timeout).await {
             Ok(t) => {
-                break (uv_proto, t, shared_secret, public_key);
+                break (uv_proto, t, shared_secret, public_key, uv_operation);
             }
             // Internal retry, because we otherwise can't fall back to PIN, if the UV is blocked
             Err(Error::Ctap(CtapError::UvBlocked)) => {
@@ -447,7 +436,9 @@ where
                     .map(|x| x.uv_retries)
                     .ok() // It's optional, so soft-error here
                     .flatten();
-                pin_provider.prompt_uv_retry(attempts_left).await;
+                channel
+                    .send_state_update(StateUpdate::UvRetry { attempts_left })
+                    .await;
                 if let Some(attempts) = attempts_left {
                     // The spec says: "If the platform receives CTAP2ERRUV_BLOCKED **or** uvRetries <= 0"
                     // So, this check MAY prevent one additional fingerprint scan for the user,
@@ -486,6 +477,7 @@ where
         pin_uv_auth_token: uv_auth_token.clone(),
         protocol_version: uv_proto.version(),
         key_agreement: public_key,
+        uv_operation,
     };
     channel.store_auth_data(auth_token_data);
 
@@ -520,7 +512,6 @@ pub(crate) async fn obtain_pin<C>(
     channel: &mut C,
     info: &Ctap2GetInfoResponse,
     pin_proto: Ctap2PinUvAuthProtocol,
-    pin_provider: &Box<dyn UvProvider>,
     reason: PinRequestReason,
     timeout: Duration,
 ) -> Result<Vec<u8>, Error>
@@ -543,9 +534,21 @@ where
         .map(|x| x.pin_retries)
         .ok() // It's optional, so soft-error here
         .flatten();
-    let Some(raw_pin) = pin_provider.provide_pin(attempts_left, reason).await else {
-        info!("User cancelled operation: no PIN provided");
-        return Err(Error::Ctap(CtapError::PINRequired));
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    channel
+        .send_state_update(StateUpdate::PinRequired {
+            reply_to: tx,
+            reason,
+            attempts_left,
+        })
+        .await;
+    let pin = match rx.await {
+        Ok(pin) => pin,
+        Err(_) => {
+            info!("User cancelled operation: no PIN provided");
+            return Err(Error::Ctap(CtapError::PINRequired));
+        }
     };
-    Ok(raw_pin.as_bytes().to_owned())
+    Ok(pin.as_bytes().to_owned())
 }


### PR DESCRIPTION
Couple of things going on here:
- Channel-creation now also returns a state update receiver that the user has to poll (currently, the spawn is outside of libwebauthn, but we could move it inside as well)
- The state update channel completely replaces the PinProvider/UvProvider trait. It will transport both generic updates ("Touch your device"), as well as provide a way (via oneshot-channels) for the application to send back the PIN.
- Introduced `PresenceRequired`-state, to tell the user when to touch the device. Some weird devices might behave differently, though, and we can't know this.
- In order to only send one `PresenceRequired`-state update, we have to also cache, if builtin UV or PIN was used in `AuthTokenData`. For UV we have to send out the update BEFORE we establish the auth token, for PIN, AFTER. And only in some cases (FIDO2 MakeCredential and GetAssertion, but not for CredentialManagement, etc.).
- Removed a few functions from `Device` that weren't really used anywhere, and moved `wink()` to the channel (mostly to avoid the additional creation of a very short lived Channel, that was thrown away after `Device::wink()` returned). 
- `Channel::wink()` didn't wait for the reply from the device.

I have tested most examples with this, except for webauthn_cable.rs 