### PR TITLE
Implement Prf

### DIFF
--- a/libwebauthn/examples/prf_test.rs
+++ b/libwebauthn/examples/prf_test.rs
@@ -1,0 +1,194 @@
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::error::Error;
+use std::io::{self, Write};
+use std::time::Duration;
+
+use libwebauthn::transport::hid::channel::HidChannel;
+use libwebauthn::UxUpdate;
+use rand::{thread_rng, Rng};
+use serde_bytes::ByteBuf;
+use text_io::read;
+use tokio::sync::mpsc::Receiver;
+use tracing_subscriber::{self, EnvFilter};
+
+use libwebauthn::ops::webauthn::{
+    GetAssertionHmacOrPrfInput, GetAssertionHmacOrPrfOutput, GetAssertionRequest,
+    GetAssertionRequestExtensions, PRFValue, UserVerificationRequirement,
+};
+use libwebauthn::pin::PinRequestReason;
+use libwebauthn::proto::ctap2::{Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialType};
+use libwebauthn::transport::hid::list_devices;
+use libwebauthn::transport::Device;
+use libwebauthn::webauthn::{Error as WebAuthnError, WebAuthn};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+fn setup_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .without_time()
+        .init();
+}
+
+async fn handle_updates(mut state_recv: Receiver<UxUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            UxUpdate::PresenceRequired => println!("Please touch your device!"),
+            UxUpdate::UvRetry { attempts_left } => {
+                print!("UV failed.");
+                if let Some(attempts_left) = attempts_left {
+                    print!(" You have {attempts_left} attempts left.");
+                }
+            }
+            UxUpdate::PinRequired(update) => {
+                let mut attempts_str = String::new();
+                if let Some(attempts) = update.attempts_left {
+                    attempts_str = format!(". You have {attempts} attempts left!");
+                };
+
+                match update.reason {
+                    PinRequestReason::RelyingPartyRequest => println!("RP required a PIN."),
+                    PinRequestReason::AuthenticatorPolicy => {
+                        println!("Your device requires a PIN.")
+                    }
+                    PinRequestReason::FallbackFromUV => {
+                        println!("UV failed too often and is blocked. Falling back to PIN.")
+                    }
+                }
+                print!("PIN: Please enter the PIN for your authenticator{attempts_str}: ");
+                io::stdout().flush().unwrap();
+                let pin_raw: String = read!("{}\n");
+
+                if pin_raw.is_empty() {
+                    println!("PIN: No PIN provided, cancelling operation.");
+                    update.cancel();
+                } else {
+                    let _ = update.send_pin(&pin_raw);
+                }
+            }
+        }
+    }
+}
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn Error>> {
+    setup_logging();
+
+    let argv: Vec<_> = std::env::args().collect();
+    if argv.len() != 3 {
+        println!("Usage: cargo run --example prf_test -- CREDENTIAL_ID FIRST_PRF_INPUT");
+        println!();
+        println!("CREDENTIAL_ID:   Credential ID to be used to sign against, as a hexstring (like 5830c80ae90f7865c631626573f1fdc7..)");
+        println!(
+            "FIRST_PRF_INPUT: PRF input to be used as a hexstring. Needs to be 32 bytes long!"
+        );
+        // println!("EXPECTED_RESULT: PRF output from the demo-webpage, that should be reproduced with this crate.");
+        println!();
+        println!("How to use:");
+        println!("1. Go to https://demo.yubico.com/webauthn-developers");
+        println!("2. Register there with PRF extension enabled, using your favorite browser");
+        println!("3. Sign in, with FIRST_PRF_INPUT set");
+        println!("4. Copy out the used hexstrings for credential_id and PRF input, and use them with this example");
+        println!("5. Hope the outputs match");
+        return Ok(());
+    }
+    let credential_id =
+        hex::decode(argv[1].clone()).expect("CREDENTIAL_ID is not a valid hex code");
+    let first_prf_input = hex::decode(argv[2].clone())
+        .expect("FIRST_PRF_INPUT is not a valid hex code")
+        .try_into()
+        .expect("FIRST_PRF_INPUT is not exactly 32 bytes long");
+
+    let devices = list_devices().await.unwrap();
+    println!("Devices found: {:?}", devices);
+
+    let challenge: [u8; 32] = thread_rng().gen();
+
+    for mut device in devices {
+        println!("Selected HID authenticator: {}", &device);
+        let (mut channel, state_recv) = device.channel().await?;
+        channel.wink(TIMEOUT).await?;
+
+        tokio::spawn(handle_updates(state_recv));
+
+        let credential = Ctap2PublicKeyCredentialDescriptor {
+            r#type: Ctap2PublicKeyCredentialType::PublicKey,
+            id: ByteBuf::from(credential_id.as_slice()),
+            transports: None,
+        };
+
+        // eval only
+        let eval = Some(PRFValue {
+            first: first_prf_input,
+            second: None,
+        });
+
+        let eval_by_credential = HashMap::new();
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_success_test(
+            &mut channel,
+            &credential,
+            &challenge,
+            hmac_or_prf,
+            "PRF output: ",
+        )
+        .await;
+    }
+    Ok(())
+}
+
+async fn run_success_test(
+    channel: &mut HidChannel<'_>,
+    credential: &Ctap2PublicKeyCredentialDescriptor,
+    challenge: &[u8; 32],
+    hmac_or_prf: GetAssertionHmacOrPrfInput,
+    printoutput: &str,
+) {
+    let get_assertion = GetAssertionRequest {
+        relying_party_id: "demo.yubico.com".to_owned(),
+        hash: Vec::from(challenge),
+        allow: vec![credential.clone()],
+        user_verification: UserVerificationRequirement::Preferred,
+        extensions: Some(GetAssertionRequestExtensions {
+            cred_blob: None,
+            hmac_or_prf,
+        }),
+        timeout: TIMEOUT,
+    };
+
+    let response = loop {
+        match channel.webauthn_get_assertion(&get_assertion).await {
+            Ok(response) => break Ok(response),
+            Err(WebAuthnError::Ctap(ctap_error)) => {
+                if ctap_error.is_retryable_user_error() {
+                    println!("Oops, try again! Error: {}", ctap_error);
+                    continue;
+                }
+                break Err(WebAuthnError::Ctap(ctap_error));
+            }
+            Err(err) => break Err(err),
+        };
+    }
+    .unwrap();
+    for (num, assertion) in response.assertions.iter().enumerate() {
+        println!(
+            "{num}. result of {printoutput}: {:?}",
+            assertion
+                .authenticator_data
+                .extensions
+                .as_ref()
+                .map(|e| match &e.hmac_or_prf {
+                    GetAssertionHmacOrPrfOutput::None => String::from("ERROR: No PRF output"),
+                    GetAssertionHmacOrPrfOutput::HmacGetSecret(..) =>
+                        String::from("ERROR: Got HMAC instead of PRF output"),
+                    GetAssertionHmacOrPrfOutput::Prf { enabled: _, result } =>
+                        hex::encode(result.first),
+                })
+                .unwrap_or(String::from("ERROR: No extensions returned"))
+        );
+    }
+}

--- a/libwebauthn/examples/webauthn_extensions_hid.rs
+++ b/libwebauthn/examples/webauthn_extensions_hid.rs
@@ -11,7 +11,8 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    GetAssertionRequest, GetAssertionRequestExtensions, HMACGetSecretInput, MakeCredentialRequest,
+    GetAssertionHmacOrPrfInput, GetAssertionRequest, GetAssertionRequestExtensions,
+    HMACGetSecretInput, MakeCredentialHmacOrPrfInput, MakeCredentialRequest,
     MakeCredentialsRequestExtensions, UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
@@ -87,7 +88,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         cred_blob: Some(r"My own little blob".into()),
         large_blob_key: None,
         min_pin_length: Some(true),
-        hmac_secret: Some(true),
+        hmac_or_prf: MakeCredentialHmacOrPrfInput::HmacGetSecret,
     };
 
     for mut device in devices {
@@ -143,7 +144,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             user_verification: UserVerificationRequirement::Discouraged,
             extensions: Some(GetAssertionRequestExtensions {
                 cred_blob: Some(true),
-                hmac_secret: Some(HMACGetSecretInput {
+                hmac_or_prf: GetAssertionHmacOrPrfInput::HmacGetSecret(HMACGetSecretInput {
                     salt1: [1; 32],
                     salt2: None,
                 }),

--- a/libwebauthn/examples/webauthn_prf_hid.rs
+++ b/libwebauthn/examples/webauthn_prf_hid.rs
@@ -1,0 +1,496 @@
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::error::Error;
+use std::io::{self, Write};
+use std::time::Duration;
+
+use libwebauthn::transport::hid::channel::HidChannel;
+use libwebauthn::UxUpdate;
+use rand::{thread_rng, Rng};
+use text_io::read;
+use tokio::sync::mpsc::Receiver;
+use tracing_subscriber::{self, EnvFilter};
+
+use libwebauthn::ops::webauthn::{
+    GetAssertionHmacOrPrfInput, GetAssertionRequest, GetAssertionRequestExtensions,
+    MakeCredentialHmacOrPrfInput, MakeCredentialRequest, MakeCredentialsRequestExtensions,
+    PRFValue, UserVerificationRequirement,
+};
+use libwebauthn::pin::PinRequestReason;
+use libwebauthn::proto::ctap2::{
+    Ctap2CredentialType, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
+    Ctap2PublicKeyCredentialUserEntity,
+};
+use libwebauthn::transport::hid::list_devices;
+use libwebauthn::transport::Device;
+use libwebauthn::webauthn::{Error as WebAuthnError, PlatformError, WebAuthn};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+fn setup_logging() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .without_time()
+        .init();
+}
+
+async fn handle_updates(mut state_recv: Receiver<UxUpdate>) {
+    while let Some(update) = state_recv.recv().await {
+        match update {
+            UxUpdate::PresenceRequired => println!("Please touch your device!"),
+            UxUpdate::UvRetry { attempts_left } => {
+                print!("UV failed.");
+                if let Some(attempts_left) = attempts_left {
+                    print!(" You have {attempts_left} attempts left.");
+                }
+            }
+            UxUpdate::PinRequired(update) => {
+                let mut attempts_str = String::new();
+                if let Some(attempts) = update.attempts_left {
+                    attempts_str = format!(". You have {attempts} attempts left!");
+                };
+
+                match update.reason {
+                    PinRequestReason::RelyingPartyRequest => println!("RP required a PIN."),
+                    PinRequestReason::AuthenticatorPolicy => {
+                        println!("Your device requires a PIN.")
+                    }
+                    PinRequestReason::FallbackFromUV => {
+                        println!("UV failed too often and is blocked. Falling back to PIN.")
+                    }
+                }
+                print!("PIN: Please enter the PIN for your authenticator{attempts_str}: ");
+                io::stdout().flush().unwrap();
+                let pin_raw: String = read!("{}\n");
+
+                if pin_raw.is_empty() {
+                    println!("PIN: No PIN provided, cancelling operation.");
+                    update.cancel();
+                } else {
+                    let _ = update.send_pin(&pin_raw);
+                }
+            }
+        }
+    }
+}
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn Error>> {
+    setup_logging();
+
+    let devices = list_devices().await.unwrap();
+    println!("Devices found: {:?}", devices);
+
+    let user_id: [u8; 32] = thread_rng().gen();
+    let challenge: [u8; 32] = thread_rng().gen();
+
+    let extensions = MakeCredentialsRequestExtensions {
+        cred_protect: None,
+        cred_blob: None,
+        large_blob_key: None,
+        min_pin_length: None,
+        hmac_or_prf: MakeCredentialHmacOrPrfInput::Prf,
+    };
+
+    for mut device in devices {
+        println!("Selected HID authenticator: {}", &device);
+        let (mut channel, state_recv) = device.channel().await?;
+        channel.wink(TIMEOUT).await?;
+
+        tokio::spawn(handle_updates(state_recv));
+
+        // Make Credentials ceremony
+        let make_credentials_request = MakeCredentialRequest {
+            origin: "example.org".to_owned(),
+            hash: Vec::from(challenge),
+            relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
+            user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
+            require_resident_key: true,
+            user_verification: UserVerificationRequirement::Preferred,
+            algorithms: vec![Ctap2CredentialType::default()],
+            exclude: None,
+            extensions: Some(extensions.clone()),
+            timeout: TIMEOUT,
+        };
+
+        let response = loop {
+            match channel
+                .webauthn_make_credential(&make_credentials_request)
+                .await
+            {
+                Ok(response) => break Ok(response),
+                Err(WebAuthnError::Ctap(ctap_error)) => {
+                    if ctap_error.is_retryable_user_error() {
+                        println!("Oops, try again! Error: {}", ctap_error);
+                        continue;
+                    }
+                    break Err(WebAuthnError::Ctap(ctap_error));
+                }
+                Err(err) => break Err(err),
+            };
+        }
+        .unwrap();
+
+        println!(
+            "WebAuthn MakeCredential extensions: {:?}",
+            response.authenticator_data.extensions
+        );
+
+        let credential: Ctap2PublicKeyCredentialDescriptor =
+            (&response.authenticator_data).try_into().unwrap();
+
+        // Test 1: eval_by_credential with the cred_id we got
+        let eval = None;
+
+        let mut eval_by_credential = HashMap::new();
+        eval_by_credential.insert(
+            base64_url::encode(&credential.id),
+            PRFValue {
+                first: [1; 32],
+                second: None,
+            },
+        );
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_success_test(
+            &mut channel,
+            &credential,
+            &challenge,
+            hmac_or_prf,
+            "eval_by_credential only",
+        )
+        .await;
+
+        // Test 2: eval and eval_with_credential with cred_id we got
+        let eval = Some(PRFValue {
+            first: [2; 32],
+            second: None,
+        });
+
+        let mut eval_by_credential = HashMap::new();
+        eval_by_credential.insert(
+            base64_url::encode(&credential.id),
+            PRFValue {
+                first: [1; 32],
+                second: None,
+            },
+        );
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_success_test(
+            &mut channel,
+            &credential,
+            &challenge,
+            hmac_or_prf,
+            "eval and eval_by_credential",
+        )
+        .await;
+
+        // Test 3: eval only
+        let eval = Some(PRFValue {
+            first: [1; 32],
+            second: None,
+        });
+
+        let eval_by_credential = HashMap::new();
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_success_test(
+            &mut channel,
+            &credential,
+            &challenge,
+            hmac_or_prf,
+            "eval only",
+        )
+        .await;
+
+        // Test 4: eval and a full list of eval_by_credential
+        let eval = Some(PRFValue {
+            first: [2; 32],
+            second: None,
+        });
+
+        let mut eval_by_credential = HashMap::new();
+        eval_by_credential.insert(
+            base64_url::encode(&[5; 54]),
+            PRFValue {
+                first: [5; 32],
+                second: None,
+            },
+        );
+        eval_by_credential.insert(
+            base64_url::encode(&[7; 54]),
+            PRFValue {
+                first: [7; 32],
+                second: Some([7; 32]),
+            },
+        );
+        eval_by_credential.insert(
+            base64_url::encode(&[8; 54]),
+            PRFValue {
+                first: [8; 32],
+                second: Some([8; 32]),
+            },
+        );
+        eval_by_credential.insert(
+            base64_url::encode(&credential.id),
+            PRFValue {
+                first: [1; 32],
+                second: None,
+            },
+        );
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_success_test(
+            &mut channel,
+            &credential,
+            &challenge,
+            hmac_or_prf,
+            "eval and full list of eval_by_credential",
+        )
+        .await;
+
+        // Test 5: eval and non-fitting list of eval_by_credential
+        let eval = Some(PRFValue {
+            first: [1; 32],
+            second: None,
+        });
+
+        let mut eval_by_credential = HashMap::new();
+        eval_by_credential.insert(
+            base64_url::encode(&[5; 54]),
+            PRFValue {
+                first: [5; 32],
+                second: None,
+            },
+        );
+        eval_by_credential.insert(
+            base64_url::encode(&[7; 54]),
+            PRFValue {
+                first: [7; 32],
+                second: Some([7; 32]),
+            },
+        );
+        eval_by_credential.insert(
+            base64_url::encode(&[8; 54]),
+            PRFValue {
+                first: [8; 32],
+                second: Some([8; 32]),
+            },
+        );
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_success_test(
+            &mut channel,
+            &credential,
+            &challenge,
+            hmac_or_prf,
+            "eval and non-fitting list of eval_by_credential",
+        )
+        .await;
+
+        // Test 6: no eval and non-fitting list of eval_by_credential
+        let eval = None;
+
+        let mut eval_by_credential = HashMap::new();
+        eval_by_credential.insert(
+            base64_url::encode(&[5; 54]),
+            PRFValue {
+                first: [5; 32],
+                second: None,
+            },
+        );
+        eval_by_credential.insert(
+            base64_url::encode(&[7; 54]),
+            PRFValue {
+                first: [7; 32],
+                second: Some([7; 32]),
+            },
+        );
+        eval_by_credential.insert(
+            base64_url::encode(&[8; 54]),
+            PRFValue {
+                first: [8; 32],
+                second: Some([8; 32]),
+            },
+        );
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_success_test(
+            &mut channel,
+            &credential,
+            &challenge,
+            hmac_or_prf,
+            "No eval and non-fitting list of eval_by_credential (should have no extension output)",
+        )
+        .await;
+
+        // Test 7: Wrongly encoded credential_id
+        let eval = Some(PRFValue {
+            first: [2; 32],
+            second: None,
+        });
+
+        let mut eval_by_credential = HashMap::new();
+        eval_by_credential.insert(
+            String::from("ÄöoLfwekldß^"),
+            PRFValue {
+                first: [1; 32],
+                second: None,
+            },
+        );
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_failed_test(
+            &mut channel,
+            Some(&credential),
+            &challenge,
+            hmac_or_prf,
+            "Wrongly encoded credential_id",
+            WebAuthnError::Platform(PlatformError::SyntaxError),
+        )
+        .await;
+
+        // Test 8: Empty credential_id
+        let eval = None;
+        let mut eval_by_credential = HashMap::new();
+        eval_by_credential.insert(
+            String::new(),
+            PRFValue {
+                first: [1; 32],
+                second: None,
+            },
+        );
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_failed_test(
+            &mut channel,
+            Some(&credential),
+            &challenge,
+            hmac_or_prf,
+            "Empty credential_id",
+            WebAuthnError::Platform(PlatformError::SyntaxError),
+        )
+        .await;
+
+        // Test 9: Empty allow_list, set eval_by_credential
+        let eval = None;
+        let mut eval_by_credential = HashMap::new();
+        eval_by_credential.insert(
+            String::new(),
+            PRFValue {
+                first: [1; 32],
+                second: None,
+            },
+        );
+        let hmac_or_prf = GetAssertionHmacOrPrfInput::Prf {
+            eval,
+            eval_by_credential,
+        };
+        run_failed_test(
+            &mut channel,
+            None,
+            &challenge,
+            hmac_or_prf,
+            "Empty allow_list, set eval_by_credential",
+            WebAuthnError::Platform(PlatformError::NotSupported),
+        )
+        .await;
+    }
+    Ok(())
+}
+
+async fn run_success_test(
+    channel: &mut HidChannel<'_>,
+    credential: &Ctap2PublicKeyCredentialDescriptor,
+    challenge: &[u8; 32],
+    hmac_or_prf: GetAssertionHmacOrPrfInput,
+    printoutput: &str,
+) {
+    let get_assertion = GetAssertionRequest {
+        relying_party_id: "example.org".to_owned(),
+        hash: Vec::from(challenge),
+        allow: vec![credential.clone()],
+        user_verification: UserVerificationRequirement::Discouraged,
+        extensions: Some(GetAssertionRequestExtensions {
+            cred_blob: None,
+            hmac_or_prf,
+        }),
+        timeout: TIMEOUT,
+    };
+
+    let response = loop {
+        match channel.webauthn_get_assertion(&get_assertion).await {
+            Ok(response) => break Ok(response),
+            Err(WebAuthnError::Ctap(ctap_error)) => {
+                if ctap_error.is_retryable_user_error() {
+                    println!("Oops, try again! Error: {}", ctap_error);
+                    continue;
+                }
+                break Err(WebAuthnError::Ctap(ctap_error));
+            }
+            Err(err) => break Err(err),
+        };
+    }
+    .unwrap();
+    for (num, assertion) in response.assertions.iter().enumerate() {
+        println!(
+            "{num}. result of {printoutput}: {:?}",
+            assertion.authenticator_data.extensions
+        );
+    }
+}
+
+async fn run_failed_test(
+    channel: &mut HidChannel<'_>,
+    credential: Option<&Ctap2PublicKeyCredentialDescriptor>,
+    challenge: &[u8; 32],
+    hmac_or_prf: GetAssertionHmacOrPrfInput,
+    printoutput: &str,
+    expected_error: WebAuthnError,
+) {
+    let get_assertion = GetAssertionRequest {
+        relying_party_id: "example.org".to_owned(),
+        hash: Vec::from(challenge),
+        allow: credential.map(|x| vec![x.clone()]).unwrap_or_default(),
+        user_verification: UserVerificationRequirement::Discouraged,
+        extensions: Some(GetAssertionRequestExtensions {
+            cred_blob: None,
+            hmac_or_prf,
+        }),
+        timeout: TIMEOUT,
+    };
+
+    let response: Result<(), libwebauthn::webauthn::Error> = loop {
+        match channel.webauthn_get_assertion(&get_assertion).await {
+            Ok(_) => panic!("Success, even though it should have errored out!"),
+            Err(WebAuthnError::Ctap(ctap_error)) => {
+                if ctap_error.is_retryable_user_error() {
+                    println!("Oops, try again! Error: {}", ctap_error);
+                    continue;
+                }
+                break Err(WebAuthnError::Ctap(ctap_error));
+            }
+            Err(err) => break Err(err),
+        };
+    };
+
+    assert_eq!(response, Err(expected_error), "{printoutput}:");
+    println!("Success for test: {printoutput}")
+}

--- a/libwebauthn/src/ops/u2f.rs
+++ b/libwebauthn/src/ops/u2f.rs
@@ -140,14 +140,15 @@ impl UpgradableResponse<MakeCredentialResponse, MakeCredentialRequest> for Regis
         // * Set "authData" to authenticatorData.
         // * Set "fmt" to "fido-u2f".
         // * Set "attStmt" to attestationStatement.
-        Ok(Ctap2MakeCredentialResponse {
+        let resp = Ctap2MakeCredentialResponse {
             format: String::from("fido-u2f"),
             authenticator_data,
             attestation_statement,
             enterprise_attestation: None,
             large_blob_key: None,
             unsigned_extension_output: None,
-        })
+        };
+        Ok(resp.into_make_credential_output(None))
     }
 }
 

--- a/libwebauthn/src/ops/u2f.rs
+++ b/libwebauthn/src/ops/u2f.rs
@@ -9,7 +9,9 @@ use x509_parser::nom::AsBytes;
 
 use super::webauthn::MakeCredentialRequest;
 use crate::fido::{AttestedCredentialData, AuthenticatorData, AuthenticatorDataFlags};
-use crate::ops::webauthn::{GetAssertionResponse, MakeCredentialResponse};
+use crate::ops::webauthn::{
+    GetAssertionRequest, GetAssertionResponse, MakeCredentialResponse, UserVerificationRequirement,
+};
 use crate::proto::ctap1::{Ctap1RegisterRequest, Ctap1SignRequest};
 use crate::proto::ctap1::{Ctap1RegisterResponse, Ctap1SignResponse};
 use crate::proto::ctap2::{
@@ -148,7 +150,7 @@ impl UpgradableResponse<MakeCredentialResponse, MakeCredentialRequest> for Regis
             large_blob_key: None,
             unsigned_extension_output: None,
         };
-        Ok(resp.into_make_credential_output(None))
+        Ok(resp.into_make_credential_output(request, None))
     }
 }
 
@@ -197,7 +199,28 @@ impl UpgradableResponse<GetAssertionResponse, SignRequest> for SignResponse {
             enterprise_attestation: None,
             attestation_statement: None,
         };
-        let upgraded_response = [response.into_assertion_output(None)].as_slice().into();
+
+        // This isn't great, but we have no access to the original request, and need to construct
+        // something like that here. In reality, we only need `extensions: None` currently.
+        let orig_request = GetAssertionRequest {
+            relying_party_id: String::new(), // We don't have access to that info here, but we don't need it either
+            hash: request.app_id_hash.clone(),
+            allow: vec![Ctap2PublicKeyCredentialDescriptor {
+                r#type: Ctap2PublicKeyCredentialType::PublicKey,
+                id: request.key_handle.clone().into(),
+                transports: None,
+            }],
+            extensions: None,
+            user_verification: if request.require_user_presence {
+                UserVerificationRequirement::Required
+            } else {
+                UserVerificationRequirement::Preferred
+            },
+            timeout: request.timeout.clone(),
+        };
+        let upgraded_response = [response.into_assertion_output(&orig_request, None)]
+            .as_slice()
+            .into();
 
         trace!(?upgraded_response);
         Ok(upgraded_response)

--- a/libwebauthn/src/ops/webauthn.rs
+++ b/libwebauthn/src/ops/webauthn.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use ctap_types::ctap2::credential_management::CredentialProtectionPolicy;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_cbor::Value;
 use sha2::{Digest, Sha256};
 use tracing::{debug, error, instrument, trace};
@@ -13,18 +13,14 @@ use crate::{
         ctap1::{Ctap1RegisteredKey, Ctap1Version},
         ctap2::{
             Ctap2AttestationStatement, Ctap2COSEAlgorithmIdentifier, Ctap2CredentialType,
-            Ctap2MakeCredentialResponse, Ctap2PublicKeyCredentialDescriptor,
-            Ctap2PublicKeyCredentialRpEntity, Ctap2PublicKeyCredentialUserEntity,
+            Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
+            Ctap2PublicKeyCredentialUserEntity,
         },
     },
     webauthn::CtapError,
 };
 
 use super::u2f::{RegisterRequest, SignRequest};
-
-// FIDO2 operations can be mapped by default to their respective CTAP2 requests.
-
-pub type MakeCredentialResponse = Ctap2MakeCredentialResponse;
 
 #[derive(Debug, Clone, Copy)]
 pub enum UserVerificationRequirement {
@@ -52,6 +48,16 @@ impl UserVerificationRequirement {
 }
 
 #[derive(Debug, Clone)]
+pub struct MakeCredentialResponse {
+    pub format: String,
+    pub authenticator_data: AuthenticatorData<MakeCredentialsResponseExtensions>,
+    pub attestation_statement: Ctap2AttestationStatement,
+    pub enterprise_attestation: Option<bool>,
+    pub large_blob_key: Option<Vec<u8>>,
+    pub unsigned_extension_output: Option<BTreeMap<Value, Value>>,
+}
+
+#[derive(Debug, Clone)]
 pub struct MakeCredentialRequest {
     pub hash: Vec<u8>,
     pub origin: String,
@@ -70,53 +76,23 @@ pub struct MakeCredentialRequest {
     pub timeout: Duration,
 }
 
-#[derive(Debug, Default, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default, Clone)]
 pub struct MakeCredentialsRequestExtensions {
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub cred_protect: Option<CredentialProtectionPolicy>,
-    #[serde(skip_serializing_if = "Option::is_none", with = "serde_bytes")]
     pub cred_blob: Option<Vec<u8>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub large_blob_key: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_pin_length: Option<bool>,
-    // Thanks, FIDO-spec for this consistent naming scheme...
-    #[serde(rename = "hmac-secret", skip_serializing_if = "Option::is_none")]
     pub hmac_secret: Option<bool>,
 }
 
-impl MakeCredentialsRequestExtensions {
-    pub fn skip_serializing(&self) -> bool {
-        self.cred_protect.is_none()
-            && self.cred_blob.is_none()
-            && self.large_blob_key.is_none()
-            && self.min_pin_length.is_none()
-            && self.hmac_secret.is_none()
-    }
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default, Clone)]
 pub struct MakeCredentialsResponseExtensions {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cred_protect: Option<CredentialProtectionPolicy>,
-    // If storing credBlob was successful
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// If storing credBlob was successful
     pub cred_blob: Option<bool>,
-    // No output provided for largeBlobKey in MakeCredential requests
-    // pub large_blob_key: Option<bool>,
-
-    // Current min PIN lenght
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Current min PIN lenght
     pub min_pin_length: Option<u32>,
-
     // Thanks, FIDO-spec for this consistent naming scheme...
-    #[serde(
-        rename = "hmac-secret",
-        default,
-        skip_serializing_if = "Option::is_none"
-    )]
     pub hmac_secret: Option<bool>,
 }
 

--- a/libwebauthn/src/proto/ctap2/model/make_credential.rs
+++ b/libwebauthn/src/proto/ctap2/model/make_credential.rs
@@ -6,11 +6,14 @@ use super::{
 use crate::{
     fido::AuthenticatorData,
     ops::webauthn::{
-        MakeCredentialRequest, MakeCredentialsRequestExtensions, MakeCredentialsResponseExtensions,
+        MakeCredentialRequest, MakeCredentialResponse, MakeCredentialsRequestExtensions,
+        MakeCredentialsResponseExtensions,
     },
     pin::PinUvAuthProtocol,
+    transport::AuthTokenData,
 };
-use serde::Serialize;
+use ctap_types::ctap2::credential_management::CredentialProtectionPolicy;
+use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use serde_cbor::Value;
 use serde_indexed::{DeserializeIndexed, SerializeIndexed};
@@ -64,7 +67,7 @@ pub struct Ctap2MakeCredentialRequest {
 
     /// extensions (0x06)
     #[serde(skip_serializing_if = "Self::skip_serializing_extensions")]
-    pub extensions: Option<MakeCredentialsRequestExtensions>,
+    pub extensions: Option<Ctap2MakeCredentialsRequestExtensions>,
 
     /// options (0x07)
     #[serde(skip_serializing_if = "Self::skip_serializing_options")]
@@ -89,7 +92,7 @@ impl Ctap2MakeCredentialRequest {
     }
 
     pub fn skip_serializing_extensions(
-        extensions: &Option<MakeCredentialsRequestExtensions>,
+        extensions: &Option<Ctap2MakeCredentialsRequestExtensions>,
     ) -> bool {
         extensions
             .as_ref()
@@ -105,7 +108,7 @@ impl From<&MakeCredentialRequest> for Ctap2MakeCredentialRequest {
             user: op.user.clone(),
             algorithms: op.algorithms.clone(),
             exclude: op.exclude.clone(),
-            extensions: op.extensions.clone(),
+            extensions: op.extensions.as_ref().map(|x| x.clone().into()),
             options: Some(Ctap2MakeCredentialOptions {
                 require_resident_key: if op.require_resident_key {
                     Some(true)
@@ -121,11 +124,49 @@ impl From<&MakeCredentialRequest> for Ctap2MakeCredentialRequest {
     }
 }
 
+#[derive(Debug, Default, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Ctap2MakeCredentialsRequestExtensions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cred_protect: Option<CredentialProtectionPolicy>,
+    #[serde(skip_serializing_if = "Option::is_none", with = "serde_bytes")]
+    pub cred_blob: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub large_blob_key: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_pin_length: Option<bool>,
+    // Thanks, FIDO-spec for this consistent naming scheme...
+    #[serde(rename = "hmac-secret", skip_serializing_if = "Option::is_none")]
+    pub hmac_secret: Option<bool>,
+}
+
+impl Ctap2MakeCredentialsRequestExtensions {
+    pub fn skip_serializing(&self) -> bool {
+        self.cred_protect.is_none()
+            && self.cred_blob.is_none()
+            && self.large_blob_key.is_none()
+            && self.min_pin_length.is_none()
+            && self.hmac_secret.is_none()
+    }
+}
+
+impl From<MakeCredentialsRequestExtensions> for Ctap2MakeCredentialsRequestExtensions {
+    fn from(other: MakeCredentialsRequestExtensions) -> Self {
+        Ctap2MakeCredentialsRequestExtensions {
+            cred_blob: other.cred_blob,
+            hmac_secret: other.hmac_secret,
+            cred_protect: other.cred_protect,
+            large_blob_key: other.large_blob_key,
+            min_pin_length: other.min_pin_length,
+        }
+    }
+}
+
 #[derive(Debug, Clone, DeserializeIndexed)]
 #[serde_indexed(offset = 1)]
 pub struct Ctap2MakeCredentialResponse {
     pub format: String,
-    pub authenticator_data: AuthenticatorData<MakeCredentialsResponseExtensions>,
+    pub authenticator_data: AuthenticatorData<Ctap2MakeCredentialsResponseExtensions>,
     pub attestation_statement: Ctap2AttestationStatement,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -138,13 +179,37 @@ pub struct Ctap2MakeCredentialResponse {
     pub unsigned_extension_output: Option<BTreeMap<Value, Value>>,
 }
 
+impl Ctap2MakeCredentialResponse {
+    pub fn into_make_credential_output(
+        self,
+        auth_data: Option<&AuthTokenData>,
+    ) -> MakeCredentialResponse {
+        let authenticator_data = AuthenticatorData::<MakeCredentialsResponseExtensions> {
+            rp_id_hash: self.authenticator_data.rp_id_hash,
+            flags: self.authenticator_data.flags,
+            signature_count: self.authenticator_data.signature_count,
+            attested_credential: self.authenticator_data.attested_credential,
+            extensions: self
+                .authenticator_data
+                .extensions
+                .map(|x| x.into_output(auth_data)),
+        };
+        MakeCredentialResponse {
+            format: self.format,
+            authenticator_data,
+            attestation_statement: self.attestation_statement,
+            enterprise_attestation: self.enterprise_attestation,
+            large_blob_key: self.large_blob_key.map(|x| x.into_vec()),
+            unsigned_extension_output: self.unsigned_extension_output,
+        }
+    }
+}
+
 impl Ctap2UserVerifiableRequest for Ctap2MakeCredentialRequest {
     fn ensure_uv_set(&mut self) {
         self.options = Some(Ctap2MakeCredentialOptions {
             deprecated_require_user_verification: Some(true),
-            ..self
-                .options
-                .unwrap_or(Ctap2MakeCredentialOptions::default())
+            ..self.options.unwrap_or_default()
         });
     }
 
@@ -164,8 +229,7 @@ impl Ctap2UserVerifiableRequest for Ctap2MakeCredentialRequest {
 
     fn permissions(&self) -> Ctap2AuthTokenPermissionRole {
         // GET_ASSERTION needed for pre-flight requests
-        return Ctap2AuthTokenPermissionRole::MAKE_CREDENTIAL
-            | Ctap2AuthTokenPermissionRole::GET_ASSERTION;
+        Ctap2AuthTokenPermissionRole::MAKE_CREDENTIAL | Ctap2AuthTokenPermissionRole::GET_ASSERTION
     }
 
     fn permissions_rpid(&self) -> Option<&str> {
@@ -178,5 +242,43 @@ impl Ctap2UserVerifiableRequest for Ctap2MakeCredentialRequest {
 
     fn handle_legacy_preview(&mut self, _info: &Ctap2GetInfoResponse) {
         // No-op
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Ctap2MakeCredentialsResponseExtensions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cred_protect: Option<CredentialProtectionPolicy>,
+    // If storing credBlob was successful
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cred_blob: Option<bool>,
+    // No output provided for largeBlobKey in MakeCredential requests
+    // pub large_blob_key: Option<bool>,
+
+    // Current min PIN lenght
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_pin_length: Option<u32>,
+
+    // Thanks, FIDO-spec for this consistent naming scheme...
+    #[serde(
+        rename = "hmac-secret",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub hmac_secret: Option<bool>,
+}
+
+impl Ctap2MakeCredentialsResponseExtensions {
+    pub fn into_output(
+        self,
+        _auth_data: Option<&AuthTokenData>,
+    ) -> MakeCredentialsResponseExtensions {
+        MakeCredentialsResponseExtensions {
+            cred_protect: self.cred_protect,
+            cred_blob: self.cred_blob,
+            min_pin_length: self.min_pin_length,
+            hmac_secret: self.hmac_secret,
+        }
     }
 }

--- a/libwebauthn/src/transport/error.rs
+++ b/libwebauthn/src/transport/error.rs
@@ -7,6 +7,8 @@ pub enum PlatformError {
     PinNotSupported,
     NoUvAvailable,
     InvalidDeviceResponse,
+    NotSupported,
+    SyntaxError,
 }
 
 impl std::error::Error for PlatformError {}

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -139,7 +139,7 @@ where
                 op.timeout
             )
         }?;
-        let make_cred = response.into_make_credential_output(self.get_auth_data());
+        let make_cred = response.into_make_credential_output(op, self.get_auth_data());
         Ok(make_cred)
     }
 
@@ -185,7 +185,7 @@ where
             }
             if let Some(auth_data) = self.get_auth_data() {
                 if let Some(e) = ctap2_request.extensions.as_mut() {
-                    e.calculate_hmac(auth_data)
+                    e.calculate_hmac(&op.allow, auth_data)?;
                 }
             }
 
@@ -197,12 +197,12 @@ where
             )
         }?;
         let count = response.credentials_count.unwrap_or(1);
-        let mut assertions = vec![response.into_assertion_output(self.get_auth_data())];
+        let mut assertions = vec![response.into_assertion_output(op, self.get_auth_data())];
         for i in 1..count {
             debug!({ i }, "Fetching additional credential");
             // GetNextAssertion doesn't use PinUVAuthToken, so we don't need to check uv_auth_used here
             let response = self.ctap2_get_next_assertion(op.timeout).await?;
-            assertions.push(response.into_assertion_output(self.get_auth_data()));
+            assertions.push(response.into_assertion_output(op, self.get_auth_data()));
         }
         Ok(assertions.as_slice().into())
     }

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -122,7 +122,7 @@ where
         op: &MakeCredentialRequest,
     ) -> Result<MakeCredentialResponse, Error> {
         let mut ctap2_request: Ctap2MakeCredentialRequest = op.into();
-        loop {
+        let response = loop {
             let uv_auth_used =
                 user_verification(self, op.user_verification, &mut ctap2_request, op.timeout)
                     .await?;
@@ -138,7 +138,9 @@ where
                 uv_auth_used,
                 op.timeout
             )
-        }
+        }?;
+        let make_cred = response.into_make_credential_output(self.get_auth_data());
+        Ok(make_cred)
     }
 
     async fn _webauthn_make_credential_u2f(


### PR DESCRIPTION
This is split into two commits:
The first one implements the translation layer from Ctap2 to Webauthn for MakeCredentials (which was, until now a No-op, and thus not implemented)

The second one then implements PRF on top of that (and the translation layer for GetAssertion).

The only 'ugly' bit to me is the U2F function (see the inline comment).

NOTE: This should be followed up by another PR implementing PreFlight for CTAP2. I think we only have it for U2F at the moment, but we need a filtered allow_list.