### PR TITLE
More extensions

### DIFF
--- a/libwebauthn/examples/prf_test.rs
+++ b/libwebauthn/examples/prf_test.rs
@@ -154,8 +154,8 @@ async fn run_success_test(
         allow: vec![credential.clone()],
         user_verification: UserVerificationRequirement::Preferred,
         extensions: Some(GetAssertionRequestExtensions {
-            cred_blob: None,
             hmac_or_prf,
+            ..Default::default()
         }),
         timeout: TIMEOUT,
     };

--- a/libwebauthn/examples/webauthn_extensions_hid.rs
+++ b/libwebauthn/examples/webauthn_extensions_hid.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::io::{self, Write};
 use std::time::Duration;
 
-use ctap_types::ctap2::credential_management::CredentialProtectionPolicy;
 use libwebauthn::UxUpdate;
 use rand::{thread_rng, Rng};
 use text_io::read;
@@ -11,9 +10,10 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    GetAssertionHmacOrPrfInput, GetAssertionRequest, GetAssertionRequestExtensions,
-    HMACGetSecretInput, MakeCredentialHmacOrPrfInput, MakeCredentialRequest,
-    MakeCredentialsRequestExtensions, UserVerificationRequirement,
+    CredentialProtectionExtension, CredentialProtectionPolicy, GetAssertionHmacOrPrfInput,
+    GetAssertionRequest, GetAssertionRequestExtensions, HMACGetSecretInput,
+    MakeCredentialHmacOrPrfInput, MakeCredentialRequest, MakeCredentialsRequestExtensions,
+    UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -84,7 +84,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     let challenge: [u8; 32] = thread_rng().gen();
 
     let extensions = MakeCredentialsRequestExtensions {
-        cred_protect: Some(CredentialProtectionPolicy::Required),
+        cred_protect: Some(CredentialProtectionExtension {
+            policy: CredentialProtectionPolicy::UserVerificationRequired,
+            enforce_policy: true,
+        }),
         cred_blob: Some(r"My own little blob".into()),
         large_blob_key: None,
         min_pin_length: Some(true),

--- a/libwebauthn/examples/webauthn_extensions_hid.rs
+++ b/libwebauthn/examples/webauthn_extensions_hid.rs
@@ -12,8 +12,8 @@ use tracing_subscriber::{self, EnvFilter};
 use libwebauthn::ops::webauthn::{
     CredentialProtectionExtension, CredentialProtectionPolicy, GetAssertionHmacOrPrfInput,
     GetAssertionRequest, GetAssertionRequestExtensions, HMACGetSecretInput,
-    MakeCredentialHmacOrPrfInput, MakeCredentialRequest, MakeCredentialsRequestExtensions,
-    UserVerificationRequirement,
+    MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension, MakeCredentialRequest,
+    MakeCredentialsRequestExtensions, UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -89,7 +89,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             enforce_policy: true,
         }),
         cred_blob: Some(r"My own little blob".into()),
-        large_blob_key: None,
+        large_blob: MakeCredentialLargeBlobExtension::None,
         min_pin_length: Some(true),
         hmac_or_prf: MakeCredentialHmacOrPrfInput::HmacGetSecret,
         cred_props: Some(true),
@@ -152,6 +152,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                     salt1: [1; 32],
                     salt2: None,
                 }),
+                ..Default::default()
             }),
             timeout: TIMEOUT,
         };

--- a/libwebauthn/examples/webauthn_extensions_hid.rs
+++ b/libwebauthn/examples/webauthn_extensions_hid.rs
@@ -92,6 +92,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         large_blob_key: None,
         min_pin_length: Some(true),
         hmac_or_prf: MakeCredentialHmacOrPrfInput::HmacGetSecret,
+        cred_props: Some(true),
     };
 
     for mut device in devices {

--- a/libwebauthn/examples/webauthn_prf_hid.rs
+++ b/libwebauthn/examples/webauthn_prf_hid.rs
@@ -85,12 +85,8 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     let challenge: [u8; 32] = thread_rng().gen();
 
     let extensions = MakeCredentialsRequestExtensions {
-        cred_protect: None,
-        cred_blob: None,
-        large_blob_key: None,
-        min_pin_length: None,
         hmac_or_prf: MakeCredentialHmacOrPrfInput::Prf,
-        cred_props: None,
+        ..Default::default()
     };
 
     for mut device in devices {
@@ -430,8 +426,8 @@ async fn run_success_test(
         allow: vec![credential.clone()],
         user_verification: UserVerificationRequirement::Discouraged,
         extensions: Some(GetAssertionRequestExtensions {
-            cred_blob: None,
             hmac_or_prf,
+            ..Default::default()
         }),
         timeout: TIMEOUT,
     };
@@ -472,8 +468,8 @@ async fn run_failed_test(
         allow: credential.map(|x| vec![x.clone()]).unwrap_or_default(),
         user_verification: UserVerificationRequirement::Discouraged,
         extensions: Some(GetAssertionRequestExtensions {
-            cred_blob: None,
             hmac_or_prf,
+            ..Default::default()
         }),
         timeout: TIMEOUT,
     };

--- a/libwebauthn/examples/webauthn_prf_hid.rs
+++ b/libwebauthn/examples/webauthn_prf_hid.rs
@@ -90,6 +90,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         large_blob_key: None,
         min_pin_length: None,
         hmac_or_prf: MakeCredentialHmacOrPrfInput::Prf,
+        cred_props: None,
     };
 
     for mut device in devices {

--- a/libwebauthn/src/ops/webauthn.rs
+++ b/libwebauthn/src/ops/webauthn.rs
@@ -159,12 +159,21 @@ impl From<Ctap2CredentialProtectionPolicy> for CredentialProtectionPolicy {
     }
 }
 
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum MakeCredentialLargeBlobExtension {
+    #[default]
+    None,
+    Preferred,
+    Required,
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct MakeCredentialsRequestExtensions {
     pub cred_props: Option<bool>,
     pub cred_protect: Option<CredentialProtectionExtension>,
     pub cred_blob: Option<Vec<u8>>,
-    pub large_blob_key: Option<bool>,
+    pub large_blob: MakeCredentialLargeBlobExtension,
     pub min_pin_length: Option<bool>,
     pub hmac_or_prf: MakeCredentialHmacOrPrfInput,
 }
@@ -240,10 +249,20 @@ pub struct HMACGetSecretInput {
     pub salt2: Option<[u8; 32]>,
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub enum GetAssertionLargeBlobExtension {
+    #[default]
+    None,
+    Read,
+    // Not yet supported
+    // Write(Vec<u8>),
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct GetAssertionRequestExtensions {
     pub cred_blob: Option<bool>,
     pub hmac_or_prf: GetAssertionHmacOrPrfInput,
+    pub large_blob: GetAssertionLargeBlobExtension,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/libwebauthn/src/ops/webauthn.rs
+++ b/libwebauthn/src/ops/webauthn.rs
@@ -161,6 +161,7 @@ impl From<Ctap2CredentialProtectionPolicy> for CredentialProtectionPolicy {
 
 #[derive(Debug, Default, Clone)]
 pub struct MakeCredentialsRequestExtensions {
+    pub cred_props: Option<bool>,
     pub cred_protect: Option<CredentialProtectionExtension>,
     pub cred_blob: Option<Vec<u8>>,
     pub large_blob_key: Option<bool>,
@@ -176,6 +177,9 @@ pub struct MakeCredentialsResponseExtensions {
     /// Current min PIN lenght
     pub min_pin_length: Option<u32>,
     pub hmac_or_prf: MakeCredentialHmacOrPrfOutput,
+    // Currently, credProps only returns one value: rk = bool
+    // If these get more in the future, we can use a struct here.
+    pub cred_props_rk: Option<bool>,
 }
 
 impl MakeCredentialRequest {

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -147,7 +147,7 @@ where
                 op.timeout
             )
         }?;
-        let make_cred = response.into_make_credential_output(op, self.get_auth_data());
+        let make_cred = response.into_make_credential_output(op, Some(&get_info_response));
         Ok(make_cred)
     }
 

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -180,7 +180,9 @@ where
         &mut self,
         op: &GetAssertionRequest,
     ) -> Result<GetAssertionResponse, Error> {
-        let mut ctap2_request: Ctap2GetAssertionRequest = op.into();
+        let get_info_response = self.ctap2_get_info().await?;
+        let mut ctap2_request =
+            Ctap2GetAssertionRequest::from_webauthn_request(op, &get_info_response)?;
         let filtered_allow_list =
             ctap2_preflight(self, &op.allow, &op.hash, &op.relying_party_id).await;
         if filtered_allow_list.is_empty() && !op.allow.is_empty() {

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -122,7 +122,9 @@ where
         &mut self,
         op: &MakeCredentialRequest,
     ) -> Result<MakeCredentialResponse, Error> {
-        let mut ctap2_request: Ctap2MakeCredentialRequest = op.into();
+        let get_info_response = self.ctap2_get_info().await?;
+        let mut ctap2_request =
+            Ctap2MakeCredentialRequest::from_webauthn_request(op, &get_info_response)?;
         if let Some(exclude_list) = &op.exclude {
             let filtered_exclude_list =
                 ctap2_preflight(self, exclude_list, &op.hash, &op.relying_party.id).await;


### PR DESCRIPTION
1. Credential protection policy: 
    a) Stop exposing `ctap_types` in our API and use our own implementation for the webauthn-layer (the CTAP layer still uses `ctap_types`)
    b) Also support `enforce_policy`, which we can only do from the inside, as we need `Ctap2GetInfoResponse` for that. Error out, if it can't be enforced.

2. Support `credProps` extension. 
    a) Pretty straight forward, except that CTAP 2.0 devices are allowed to create discoverable credentials even if they are not requested. CTAP 2.1 devices are not allowed to do that anymore. So we need `Ctap2GetInfoResponse` once again to decide

3. Switch from LargeBlobKeys extension to LargeBlob extension.
    a) LargeBlob extension has "Preferred"-mode as well, so we need `Ctap2GetInfoResponse` again for deciding, if we can request it or not.
    b) LargeBlobKey-requests can easily be mapped into LargeBlob requests, by simply using LargeBlob `support = "required"`, so I'm not supporting both in the API.
    c) `GetAssertionLargeBlobExtension::Write()` is not yet supported, as we need the corresponding CTAP commands to store large blobs for that, which we don't have yet.