### PR TITLE
Fix #95, correct key ordering for CBOR encoding

### DIFF
--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -41,7 +41,7 @@ num_enum = "0.7.1"
 x509-parser = "0.16.0"
 time = "0.3.35"
 curve25519-dalek = "4.1.3"
-hex = "0.4.2"
+hex = "0.4.3"
 mockall = "0.11.4"
 hidapi = { version = "2.4.1", default-features = false, features = [
     "linux-static-hidraw",


### PR DESCRIPTION
See #95.

No trivial root-cause fix due to serde_cbor, but thankfully the CBOR data structures with string keys in libwebauthn are limited.

Added tests to prevent regressions.


## Test vectors

As decoded by [cbor.me](https://cbor.me).

### Ctap2CredentialType

```
A2                         # map(2)
   63                      # text(3)
      616C67               # "alg"
   26                      # negative(6)
   64                      # text(4)
      74797065             # "type"
   6A                      # text(10)
      7075626C69632D6B6579 # "public-key"
```

### Ctap2PublicKeyCredentialDescriptor

```
A2                         # map(2)
   62                      # text(2)
      6964                 # "id"
   41                      # bytes(1)
      42                   # "B"
   64                      # text(4)
      74797065             # "type"
   6A                      # text(10)
      7075626C69632D6B6579 # "public-key"
```