### PR TITLE
Fix #52: QR-initiated hybrid transport support on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _Looking for the D-Bus API proposal?_ Check out [platform-api][linux-credentials
   - 🟢 GetPinUvAuthTokenUsingUvWithPermissions
 - [Passkey Authentication][passkeys]
   - 🟢 Discoverable credentials (resident keys)
-  - 🟢 Hybrid transport (caBLE v2): QR-initiated transactions ([#52][#52]: iOS only)
+  - 🟢 Hybrid transport (caBLE v2): QR-initiated transactions
   - 🟠 Hybrid transport (caBLE v2): State-assisted transactions ([#31][#31]: planned)
 
 ## Transports

--- a/libwebauthn/examples/webauthn_cable.rs
+++ b/libwebauthn/examples/webauthn_cable.rs
@@ -25,7 +25,7 @@ use libwebauthn::proto::ctap2::{
 use libwebauthn::transport::Device;
 use libwebauthn::webauthn::{Error as WebAuthnError, WebAuthn};
 
-const TIMEOUT: Duration = Duration::from_secs(10);
+const TIMEOUT: Duration = Duration::from_secs(120);
 
 fn setup_logging() {
     tracing_subscriber::fmt()

--- a/libwebauthn/src/pin.rs
+++ b/libwebauthn/src/pin.rs
@@ -391,7 +391,10 @@ where
             return Err(Error::Platform(PlatformError::PinTooLong));
         }
 
-        let uv_proto = select_uv_proto(&get_info_response).await?;
+        let Some(uv_proto) = select_uv_proto(&get_info_response).await else {
+            error!("No supported PIN/UV auth protocols found");
+            return Err(Error::Ctap(CtapError::Other));
+        };
 
         let current_pin = match get_info_response.options.as_ref().unwrap().get("clientPin") {
             // Obtaining the current PIN, if one is set

--- a/libwebauthn/src/proto/ctap2/protocol.rs
+++ b/libwebauthn/src/proto/ctap2/protocol.rs
@@ -101,11 +101,11 @@ where
     async fn ctap2_make_credential(
         &mut self,
         request: &Ctap2MakeCredentialRequest,
-        _timeout: Duration,
+        timeout: Duration,
     ) -> Result<Ctap2MakeCredentialResponse, Error> {
         trace!(?request);
-        self.cbor_send(&request.into(), TIMEOUT_GET_INFO).await?;
-        let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
+        self.cbor_send(&request.into(), timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -121,11 +121,11 @@ where
     async fn ctap2_get_assertion(
         &mut self,
         request: &Ctap2GetAssertionRequest,
-        _timeout: Duration,
+        timeout: Duration,
     ) -> Result<Ctap2GetAssertionResponse, Error> {
         trace!(?request);
-        self.cbor_send(&request.into(), TIMEOUT_GET_INFO).await?;
-        let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
+        self.cbor_send(&request.into(), timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -140,12 +140,12 @@ where
     #[instrument(skip_all)]
     async fn ctap2_get_next_assertion(
         &mut self,
-        _timeout: Duration,
+        timeout: Duration,
     ) -> Result<Ctap2GetAssertionResponse, Error> {
         debug!("CTAP2 GetNextAssertion request");
         let cbor_request = CborRequest::new(Ctap2CommandCode::AuthenticatorGetNextAssertion);
-        self.cbor_send(&cbor_request, TIMEOUT_GET_INFO).await?;
-        let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
+        self.cbor_send(&cbor_request, timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         let data = unwrap_field!(cbor_response.data);
         let ctap_response = parse_cbor!(Ctap2GetAssertionResponse, &data);
         debug!("CTAP2 GetNextAssertion successful");
@@ -154,13 +154,13 @@ where
     }
 
     #[instrument(skip_all)]
-    async fn ctap2_selection(&mut self, _timeout: Duration) -> Result<(), Error> {
+    async fn ctap2_selection(&mut self, timeout: Duration) -> Result<(), Error> {
         debug!("CTAP2 Authenticator Selection request");
         let cbor_request = CborRequest::new(Ctap2CommandCode::AuthenticatorSelection);
 
         loop {
-            self.cbor_send(&cbor_request, TIMEOUT_GET_INFO).await?;
-            let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
+            self.cbor_send(&cbor_request, timeout).await?;
+            let cbor_response = self.cbor_recv(timeout).await?;
             match cbor_response.status_code {
                 CtapError::Ok => {
                     return Ok(());
@@ -177,11 +177,11 @@ where
     async fn ctap2_client_pin(
         &mut self,
         request: &Ctap2ClientPinRequest,
-        _timeou: Duration,
+        timeout: Duration,
     ) -> Result<Ctap2ClientPinResponse, Error> {
         trace!(?request);
-        self.cbor_send(&request.into(), TIMEOUT_GET_INFO).await?;
-        let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
+        self.cbor_send(&request.into(), timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -203,11 +203,11 @@ where
     async fn ctap2_authenticator_config(
         &mut self,
         request: &Ctap2AuthenticatorConfigRequest,
-        _timeout: Duration,
+        timeout: Duration,
     ) -> Result<(), Error> {
         trace!(?request);
-        self.cbor_send(&request.into(), TIMEOUT_GET_INFO).await?;
-        let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
+        self.cbor_send(&request.into(), timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => {
                 return Ok(());
@@ -226,11 +226,11 @@ where
     async fn ctap2_bio_enrollment(
         &mut self,
         request: &Ctap2BioEnrollmentRequest,
-        _timeout: Duration,
+        timeout: Duration,
     ) -> Result<Ctap2BioEnrollmentResponse, Error> {
         trace!(?request);
-        self.cbor_send(&request.into(), TIMEOUT_GET_INFO).await?;
-        let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
+        self.cbor_send(&request.into(), timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -252,11 +252,11 @@ where
     async fn ctap2_credential_management(
         &mut self,
         request: &Ctap2CredentialManagementRequest,
-        _timeout: Duration,
+        timeout: Duration,
     ) -> Result<Ctap2CredentialManagementResponse, Error> {
         trace!(?request);
-        self.cbor_send(&request.into(), TIMEOUT_GET_INFO).await?;
-        let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
+        self.cbor_send(&request.into(), timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),

--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -104,6 +104,11 @@ impl<'d> Channel for CableChannel<'d> {
     fn get_state_sender(&self) -> &mpsc::Sender<UxUpdate> {
         &self.tx
     }
+
+    fn supports_preflight() -> bool {
+        // Disable pre-flight requests, as hybrid transport authenticators do not support silent requests.
+        false
+    }
 }
 
 impl<'d> Ctap2AuthTokenStore for CableChannel<'d> {

--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -83,7 +83,10 @@ impl<'d> Channel for CableChannel<'d> {
                 error!(%error, "CBOR request send failure");
                 Err(Error::Transport(TransportError::TransportUnavailable))
             }
-            Err(_) => Err(Error::Transport(TransportError::Timeout)),
+            Err(elapsed) => {
+                error!({ %elapsed, ?timeout }, "CBOR request send timeout");
+                Err(Error::Transport(TransportError::Timeout))
+            }
         }
     }
 
@@ -91,7 +94,10 @@ impl<'d> Channel for CableChannel<'d> {
         match time::timeout(timeout, self.cbor_receiver.recv()).await {
             Ok(Some(response)) => Ok(response),
             Ok(None) => Err(Error::Transport(TransportError::TransportUnavailable)),
-            Err(_) => Err(Error::Transport(TransportError::Timeout)),
+            Err(elapsed) => {
+                error!({ %elapsed, ?timeout }, "CBOR response recv timeout");
+                Err(Error::Transport(TransportError::Timeout))
+            }
         }
     }
 

--- a/libwebauthn/src/transport/cable/tunnel.rs
+++ b/libwebauthn/src/transport/cable/tunnel.rs
@@ -88,6 +88,10 @@ struct CableInitialMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub _padding: Option<ByteBuf>,
     pub info: ByteBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub _unused_2: Option<()>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub _supported_features: Option<Vec<String>>,
 }
 
 #[repr(u8)]

--- a/libwebauthn/src/transport/channel.rs
+++ b/libwebauthn/src/transport/channel.rs
@@ -47,6 +47,11 @@ pub trait Channel: Send + Sync + Display + Ctap2AuthTokenStore {
 
     async fn cbor_send(&mut self, request: &CborRequest, timeout: Duration) -> Result<(), Error>;
     async fn cbor_recv(&mut self, timeout: Duration) -> Result<CborResponse, Error>;
+
+    /// Allows channels to disable support for pre-flight requests
+    fn supports_preflight() -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Changes

See [list of commits](https://github.com/linux-credentials/libwebauthn/pull/97/commits) for individual changes.

## Testing

Tested successfully with a Pixel 8 Pro running Android 15.

Creation & assertion are successful using Bitwarden on the phone.

## Motivation 

I was originally getting a HTTP 400 error upon connecting to Google's caBLE servers:

```
DEBUG libwebauthn::transport::cable::tunnel: Connecting to tunnel server connect_url="wss://cable.ua5v.com/cable/connect/078f8a/4daa63321c9414caecee728764b0b3c9"
DEBUG rustls::anchors: add_parsable_certificates processed 148 valid and 0 invalid certs    
DEBUG tokio_tungstenite::tls::encryption::rustls: Added 148/148 native root certificates (ignored 0)    
DEBUG rustls::client::hs: No cached session for DnsName("cable.ua5v.com")    
DEBUG rustls::client::hs: Not resuming any session    
DEBUG rustls::client::hs: Using ciphersuite TLS13_AES_256_GCM_SHA384    
DEBUG rustls::client::tls13: Not resuming    
DEBUG rustls::client::tls13: TLS1.3 encrypted extensions: []    
DEBUG rustls::client::hs: ALPN protocol is None    
ERROR libwebauthn::transport::cable::tunnel: Failed to connect to tunnel server e=Http(Response { status: 400, version: HTTP/1.1, headers: {"content-length": "1451", "content-security-policy-report-only": "script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/goa-55573edb", "content-type": "text/html; charset=utf-8", "cross-origin-opener-policy-report-only": "same-origin; report-to=\"goa-55573edb\"", "report-to": "{\"group\":\"goa-55573edb\",\"max_age\":2592000,\"endpoints\":[{\"url\":\"https://csp.withgoogle.com/csp/report-to/goa-55573edb\"}]}", "x-content-type-options": "nosniff", "x-frame-options": "SAMEORIGIN", "x-xss-protection": "0", "date": "Mon, 05 May 2025 10:40:43 GMT", "alt-svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000", "connection": "close"}, body: Some([10, 60, 33, 68, 79, 67, 84, 89, 80, 69, 32, 104, 116, 109, 108, 62, 10, 60, 104, 116, 109, 108, 32, 108, 97, 110, 103, 61, 101, 110, 62, 10, 32, 32, 60, 109, 101, 116, 97, ...]) })

thread 'main' panicked at libwebauthn/examples/webauthn_cable.rs:98:60:
called `Result::unwrap()` on an `Err` value: Transport(ConnectionFailed)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This was fixed by setting the `fido.cable` subprotocol on the WSS request.

Then, we were failing to decode the CBOR payload received over the tunnel:

```
TRACE libwebauthn::transport::cable::tunnel: Trimmed padding decrypted_frame=[...] decrypted_frame_len=97
ERROR libwebauthn::transport::cable::tunnel: Failed to decode initial message e=SerdeDeCustom
ERROR libwebauthn::transport::cable::tunnel: Failed to process initial message e=Transport(ConnectionFailed)

thread 'main' panicked at libwebauthn/examples/webauthn_cable.rs:136:6:
called `Result::unwrap()` on an `Err` value: Transport(TransportUnavailable)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This was caused by missing fields in `CableInitialMessage`, which now includes a list of features (CTAP and digital credentials) as strings

Once added, I was getting an error for missing supported PI/UV auth protocols:

```
DEBUG webauthn_make_credential{dev=CableChannel}:user_verification:ctap2_get_info: libwebauthn::proto::ctap2::protocol: CTAP2 GetInfo successful
TRACE webauthn_make_credential{dev=CableChannel}:user_verification:ctap2_get_info: libwebauthn::proto::ctap2::protocol: ctap_response=Ctap2GetInfoResponse { versions: ["FIDO_2_0", "FIDO_2_1"], extensions: Some(["prf"]), aaguid: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], options: Some({"up": true, "rk": true, "plat": false, "uv": true}), max_msg_size: None, pin_auth_protos: None, max_credential_count: None, max_credential_id_length: None, transports: Some(["internal", "hybrid"]), algorithms: None, max_blob_array: None, force_pin_change: None, min_pin_length: None, firmware_version: None, max_cred_blob_length: None, max_rpids_for_setminpinlength: None, preferred_platform_uv_attempts: None, uv_modality: None, certifications: None, remaining_discoverable_creds: None, vendor_proto_config_cmds: None, attestation_formats: None, uv_count_since_last_pin_entry: None, long_touch_for_reset: None, enc_identifier: None, transports_for_reset: None, pin_complexity_policy: None, pin_complexity_policy_url: None, max_pin_length: None }
ERROR webauthn_make_credential{dev=CableChannel}:user_verification: libwebauthn::webauthn: No supported PIN/UV auth protocols found get_info_response.pin_auth_protos=None

thread 'main' panicked at libwebauthn/examples/webauthn_cable.rs:136:6:
called `Result::unwrap()` on an `Err` value: Ctap(Other)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

So I modified `select_uv_proto` to allow empty an empty GetInfo `pinUvAuthProtocols` field if no UV is required.

Now, the connection would get interrupted midway through the transaction. Checking `adb logcat`, I could see this is due to #95:

```
05-05 13:48:22.616  7975  3808 E Fido    : bfvv: the data in the message can't be decoded into CBOR
05-05 13:48:22.616  7975  3808 E Fido    : 	at bfvm.f(:com.google.android.gms@251633035@25.16.33 (260400-750736914):2416)
05-05 13:48:22.616  7975  3808 E Fido    : 	at bgty.a(:com.google.android.gms@251633035@25.16.33 (260400-750736914):235)
05-05 13:48:22.616  7975  3808 E Fido    : 	at bgtr.run(:com.google.android.gms@251633035@25.16.33 (260400-750736914):640)
05-05 13:48:22.616  7975  3808 E Fido    : 	at java.lang.Thread.run(Thread.java:1012)
05-05 13:48:22.616  7975  3808 E Fido    : Caused by: gqbb: Error in decoding CborValue from bytes
05-05 13:48:22.616  7975  3808 E Fido    : 	at gqbj.b(:com.google.android.gms@251633035@25.16.33 (260400-750736914):355)
05-05 13:48:22.616  7975  3808 E Fido    : 	at gqbj.a(:com.google.android.gms@251633035@25.16.33 (260400-750736914):1)
05-05 13:48:22.616  7975  3808 E Fido    : 	at gqbi.q(:com.google.android.gms@251633035@25.16.33 (260400-750736914):19)
05-05 13:48:22.616  7975  3808 E Fido    : 	at bfvm.f(:com.google.android.gms@251633035@25.16.33 (260400-750736914):1318)
05-05 13:48:22.616  7975  3808 E Fido    : 	... 3 more
05-05 13:48:22.616  7975  3808 E Fido    : Caused by: gqbb: Error in decoding CborValue from bytes
05-05 13:48:22.616  7975  3808 E Fido    : 	at gqbj.b(:com.google.android.gms@251633035@25.16.33 (260400-750736914):355)
05-05 13:48:22.616  7975  3808 E Fido    : 	at gqbj.b(:com.google.android.gms@251633035@25.16.33 (260400-750736914):243)
05-05 13:48:22.616  7975  3808 E Fido    : 	... 6 more
05-05 13:48:22.616  7975  3808 E Fido    : Caused by: gqbb: Error in decoding CborValue from bytes
05-05 13:48:22.616  7975  3808 E Fido    : 	at gqbj.b(:com.google.android.gms@251633035@25.16.33 (260400-750736914):355)
05-05 13:48:22.616  7975  3808 E Fido    : 	at gqbj.b(:com.google.android.gms@251633035@25.16.33 (260400-750736914):305)
05-05 13:48:22.616  7975  3808 E Fido    : 	... 7 more
05-05 13:48:22.616  7975  3808 E Fido    : Caused by: gqax: Keys in CBOR Map not in strictly ascending natural order:
05-05 13:48:22.616  7975  3808 E Fido    : Previous key: "type"
05-05 13:48:22.616  7975  3808 E Fido    : Current key: "alg"
05-05 13:48:22.616  7975  3808 E Fido    : 	at gqbj.b(:com.google.android.gms@251633035@25.16.33 (260400-750736914):237)
05-05 13:48:22.616  7975  3808 E Fido    : 	... 8 more
```

So I rebased on top of `master` which includes fix #96.

Then UX was encountering request timeouts, so I updated the code to support user-defined timeout values.

Finally, pre-flight requests were timing out because Android shows UI for pre-flight requests. These are not supported, as they should be silent. 

```
ERROR webauthn_get_assertion{dev=CableChannel}:ctap2_get_assertion: libwebauthn::transport::cable::channel: CBOR response recv timeout elapsed=deadline has elapsed timeout=2s
DEBUG webauthn_get_assertion{dev=CableChannel}: libwebauthn::proto::ctap2::preflight: Pre-flight: Filtering out Ctap2PublicKeyCredentialDescriptor { id: [233, 220, 252, 82, 44, 76, 57, 246, 46, 170, 235, 207, 111, 237, 29, 118], type: PublicKey, transports: None }, because of error: Transport(Timeout)
 INFO webauthn_get_assertion{dev=CableChannel}: libwebauthn::proto::ctap2::preflight: Credential list AFTER preflight: []
 WARN webauthn_get_assertion{dev=CableChannel}: libwebauthn::webauthn: Preflight removed all credentials from the allow-list. Sending dummy request and erroring out.
```

As pre-flights are an optional operation, they are now skipped for Hybrid transport authenticators.
