### PR TITLE
Hybrid transport: Add state-assisted transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ _Looking for the D-Bus API proposal?_ Check out [platform-api][linux-credentials
 - [Passkey Authentication][passkeys]
   - 🟢 Discoverable credentials (resident keys)
   - 🟢 Hybrid transport (caBLE v2): QR-initiated transactions
-  - 🟠 Hybrid transport (caBLE v2): State-assisted transactions ([#31][#31]: planned)
+  - 🟢 Hybrid transport (caBLE v2): State-assisted transactions (remember this phone)
 
 ## Transports
 
 |                      | USB (HID)                 | Bluetooth Low Energy (BLE) | NFC                   | TPM 2.0 (Platform)    | Hybrid (caBLEv2)                   |
 | -------------------- | ------------------------- | -------------------------- | --------------------- | --------------------- | ---------------------------------- |
 | **FIDO U2F**         | 🟢 Supported (via hidapi) | 🟢 Supported (via bluez)   | 🟠 Planned ([#5][#5]) | 🟠 Planned ([#4][#4]) | N/A                                |
-| **WebAuthn (FIDO2)** | 🟢 Supported (via hidapi) | 🟢 Supported (via bluez)   | 🟠 Planned ([#5][#5]) | 🟠 Planned ([#4][#4]) | 🟠 Partly implemented ([#31][#31]) |
+| **WebAuthn (FIDO2)** | 🟢 Supported (via hidapi) | 🟢 Supported (via bluez)   | 🟠 Planned ([#5][#5]) | 🟠 Planned ([#4][#4]) | 🟢 Supported |
 
 ## Example programs
 

--- a/libwebauthn/examples/webauthn_cable.rs
+++ b/libwebauthn/examples/webauthn_cable.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::transport::cable::known_devices::{
-    CableKnownDeviceInfoStore, EphemeralDeviceInfoStore,
+    self, CableKnownDevice, CableKnownDeviceId, CableKnownDeviceInfoStore, EphemeralDeviceInfoStore,
 };
 use libwebauthn::transport::cable::qr_code_device::{CableQrCodeDevice, QrCodeOperationHint};
 use libwebauthn::UxUpdate;
@@ -14,6 +14,7 @@ use qrcode::QrCode;
 use rand::{thread_rng, Rng};
 use text_io::read;
 use tokio::sync::mpsc::Receiver;
+use tokio::time::sleep;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
@@ -79,68 +80,71 @@ async fn handle_updates(mut state_recv: Receiver<UxUpdate>) {
 pub async fn main() -> Result<(), Box<dyn Error>> {
     setup_logging();
 
-    let device_info_store: Arc<dyn CableKnownDeviceInfoStore> =
-        Arc::new(EphemeralDeviceInfoStore::default());
-
-    // Create QR code
-    let mut device: CableQrCodeDevice = CableQrCodeDevice::new_persistent(
-        QrCodeOperationHint::MakeCredential,
-        device_info_store.clone(),
-    );
-
-    println!("Created QR code, awaiting for advertisement.");
-    let qr_code = QrCode::new(device.qr_code.to_string()).unwrap();
-    let image = qr_code
-        .render::<unicode::Dense1x2>()
-        .dark_color(unicode::Dense1x2::Light)
-        .light_color(unicode::Dense1x2::Dark)
-        .build();
-    println!("{}", image);
-
-    // Connect to a known device
-    let (mut channel, state_recv) = device.channel().await.unwrap();
-    println!("Tunnel established {:?}", channel);
-
-    tokio::spawn(handle_updates(state_recv));
-
+    let device_info_store = Arc::new(EphemeralDeviceInfoStore::default());
     let user_id: [u8; 32] = thread_rng().gen();
     let challenge: [u8; 32] = thread_rng().gen();
 
-    // Make Credentials ceremony
-    let make_credentials_request = MakeCredentialRequest {
-        origin: "example.org".to_owned(),
-        hash: Vec::from(challenge),
-        relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
-        user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-        require_resident_key: false,
-        user_verification: UserVerificationRequirement::Preferred,
-        algorithms: vec![Ctap2CredentialType::default()],
-        exclude: None,
-        extensions: None,
-        timeout: TIMEOUT,
+    let credential: Ctap2PublicKeyCredentialDescriptor = {
+        // Create QR code
+        let mut device: CableQrCodeDevice = CableQrCodeDevice::new_persistent(
+            QrCodeOperationHint::MakeCredential,
+            device_info_store.clone(),
+        );
+
+        println!("Created QR code, awaiting for advertisement.");
+        let qr_code = QrCode::new(device.qr_code.to_string()).unwrap();
+        let image = qr_code
+            .render::<unicode::Dense1x2>()
+            .dark_color(unicode::Dense1x2::Light)
+            .light_color(unicode::Dense1x2::Dark)
+            .build();
+        println!("{}", image);
+
+        // Connect to a known device
+        let (mut channel, state_recv) = device.channel().await.unwrap();
+        println!("Tunnel established {:?}", channel);
+
+        tokio::spawn(handle_updates(state_recv));
+
+        // Make Credentials ceremony
+        let make_credentials_request = MakeCredentialRequest {
+            origin: "example.org".to_owned(),
+            hash: Vec::from(challenge),
+            relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
+            user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
+            require_resident_key: false,
+            user_verification: UserVerificationRequirement::Preferred,
+            algorithms: vec![Ctap2CredentialType::default()],
+            exclude: None,
+            extensions: None,
+            timeout: TIMEOUT,
+        };
+
+        let response = loop {
+            match channel
+                .webauthn_make_credential(&make_credentials_request)
+                .await
+            {
+                Ok(response) => break Ok(response),
+                Err(WebAuthnError::Ctap(ctap_error)) => {
+                    if ctap_error.is_retryable_user_error() {
+                        println!("Oops, try again! Error: {}", ctap_error);
+                        continue;
+                    }
+                    break Err(WebAuthnError::Ctap(ctap_error));
+                }
+                Err(err) => break Err(err),
+            };
+        }
+        .unwrap();
+        println!("WebAuthn MakeCredential response: {:?}", response);
+
+        (&response.authenticator_data).try_into().unwrap()
     };
 
-    let response = loop {
-        match channel
-            .webauthn_make_credential(&make_credentials_request)
-            .await
-        {
-            Ok(response) => break Ok(response),
-            Err(WebAuthnError::Ctap(ctap_error)) => {
-                if ctap_error.is_retryable_user_error() {
-                    println!("Oops, try again! Error: {}", ctap_error);
-                    continue;
-                }
-                break Err(WebAuthnError::Ctap(ctap_error));
-            }
-            Err(err) => break Err(err),
-        };
-    }
-    .unwrap();
-    println!("WebAuthn MakeCredential response: {:?}", response);
+    println!("Waiting for 10 seconds before contacting the device...");
+    sleep(Duration::from_secs(30)).await;
 
-    let credential: Ctap2PublicKeyCredentialDescriptor =
-        (&response.authenticator_data).try_into().unwrap();
     let get_assertion = GetAssertionRequest {
         relying_party_id: "example.org".to_owned(),
         hash: Vec::from(challenge),
@@ -150,24 +154,17 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         timeout: TIMEOUT,
     };
 
-    // Create QR code
-    let mut device: CableQrCodeDevice = CableQrCodeDevice::new_persistent(
-        QrCodeOperationHint::GetAssertionRequest,
-        device_info_store.clone(),
-    );
+    let all_devices = device_info_store.list_all().await;
+    let (_known_device_id, known_device_info) =
+        all_devices.first().expect("No known devices found");
 
-    println!("Created QR code, awaiting for advertisement.");
-    let qr_code = QrCode::new(device.qr_code.to_string()).unwrap();
-    let image = qr_code
-        .render::<unicode::Dense1x2>()
-        .dark_color(unicode::Dense1x2::Light)
-        .light_color(unicode::Dense1x2::Dark)
-        .build();
-    println!("{}", image);
+    let mut known_device: CableKnownDevice =
+        CableKnownDevice::new(known_device_info, device_info_store.clone())
+            .await
+            .unwrap();
 
     // Connect to a known device
-    println!("Tunnel established {:?}", channel);
-    let (mut channel, state_recv) = device.channel().await.unwrap();
+    let (mut channel, state_recv) = known_device.channel().await.unwrap();
     println!("Tunnel established {:?}", channel);
 
     tokio::spawn(handle_updates(state_recv));

--- a/libwebauthn/examples/webauthn_cable.rs
+++ b/libwebauthn/examples/webauthn_cable.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::transport::cable::known_devices::{
-    self, CableKnownDevice, CableKnownDeviceId, CableKnownDeviceInfoStore, EphemeralDeviceInfoStore,
+    CableKnownDevice, ClientPayloadHint, EphemeralDeviceInfoStore,
 };
 use libwebauthn::transport::cable::qr_code_device::{CableQrCodeDevice, QrCodeOperationHint};
 use libwebauthn::UxUpdate;
@@ -142,8 +142,8 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         (&response.authenticator_data).try_into().unwrap()
     };
 
-    println!("Waiting for 10 seconds before contacting the device...");
-    sleep(Duration::from_secs(30)).await;
+    println!("Waiting for 5 seconds before contacting the device...");
+    sleep(Duration::from_secs(5)).await;
 
     let get_assertion = GetAssertionRequest {
         relying_party_id: "example.org".to_owned(),
@@ -158,10 +158,13 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
     let (_known_device_id, known_device_info) =
         all_devices.first().expect("No known devices found");
 
-    let mut known_device: CableKnownDevice =
-        CableKnownDevice::new(known_device_info, device_info_store.clone())
-            .await
-            .unwrap();
+    let mut known_device: CableKnownDevice = CableKnownDevice::new(
+        ClientPayloadHint::GetAssertion,
+        known_device_info,
+        device_info_store.clone(),
+    )
+    .await
+    .unwrap();
 
     // Connect to a known device
     let (mut channel, state_recv) = known_device.channel().await.unwrap();

--- a/libwebauthn/src/transport/ble/btleplug/manager.rs
+++ b/libwebauthn/src/transport/ble/btleplug/manager.rs
@@ -56,7 +56,7 @@ async fn on_peripheral_service_data(
     id: &PeripheralId,
     uuids: &[Uuid],
     service_data: HashMap<Uuid, Vec<u8>>,
-) -> Option<(Peripheral, Vec<u8>)> {
+) -> Option<(Adapter, Peripheral, Vec<u8>)> {
     for uuid in uuids {
         if let Some(service_data) = service_data.get(uuid) {
             trace!(?id, ?service_data, "Found service data");
@@ -66,7 +66,7 @@ async fn on_peripheral_service_data(
             };
 
             debug!({ ?id, ?service_data }, "Found service data for peripheral");
-            return Some((peripheral, service_data.to_owned()));
+            return Some((adapter.clone(), peripheral, service_data.to_owned()));
         }
     }
 
@@ -81,7 +81,7 @@ async fn on_peripheral_service_data(
 /// Starts a discovery for devices advertising service data on any of the provided UUIDs
 pub async fn start_discovery_for_service_data(
     uuids: &[Uuid],
-) -> Result<impl Stream<Item = (Peripheral, Vec<u8>)> + use<'_>, Error> {
+) -> Result<impl Stream<Item = (Adapter, Peripheral, Vec<u8>)> + use<'_>, Error> {
     let adapter = get_adapter().await?;
     let scan_filter = ScanFilter::default();
 

--- a/libwebauthn/src/transport/cable/advertisement.rs
+++ b/libwebauthn/src/transport/cable/advertisement.rs
@@ -19,8 +19,8 @@ pub(crate) struct DecryptedAdvert {
     pub encoded_tunnel_server_domain: u16,
 }
 
-impl From<&[u8]> for DecryptedAdvert {
-    fn from(plaintext: &[u8]) -> Self {
+impl From<[u8; 16]> for DecryptedAdvert {
+    fn from(plaintext: [u8; 16]) -> Self {
         let mut nonce = [0u8; 10];
         nonce.copy_from_slice(&plaintext[1..11]);
         let mut routing_id = [0u8; 3];
@@ -70,7 +70,7 @@ pub(crate) async fn await_advertisement(
         };
         trace!(?decrypted);
 
-        let advert = DecryptedAdvert::from(decrypted.as_slice());
+        let advert = DecryptedAdvert::from(decrypted);
         debug!(
             ?device,
             ?decrypted,

--- a/libwebauthn/src/transport/cable/advertisement.rs
+++ b/libwebauthn/src/transport/cable/advertisement.rs
@@ -1,0 +1,90 @@
+use ::btleplug::api::Central;
+use futures::StreamExt;
+use std::pin::pin;
+use tracing::{debug, trace, warn};
+use uuid::Uuid;
+
+use crate::transport::ble::btleplug::{self, FidoDevice};
+use crate::transport::cable::crypto::trial_decrypt_advert;
+use crate::webauthn::{Error, TransportError};
+
+const CABLE_UUID_FIDO: &str = "0000fff9-0000-1000-8000-00805f9b34fb";
+const CABLE_UUID_GOOGLE: &str = "0000fde2-0000-1000-8000-00805f9b34fb";
+
+#[derive(Debug)]
+pub(crate) struct DecryptedAdvert {
+    pub plaintext: [u8; 16],
+    pub nonce: [u8; 10],
+    pub routing_id: [u8; 3],
+    pub encoded_tunnel_server_domain: u16,
+}
+
+impl From<&[u8]> for DecryptedAdvert {
+    fn from(plaintext: &[u8]) -> Self {
+        let mut nonce = [0u8; 10];
+        nonce.copy_from_slice(&plaintext[1..11]);
+        let mut routing_id = [0u8; 3];
+        routing_id.copy_from_slice(&plaintext[11..14]);
+        let encoded_tunnel_server_domain = u16::from_le_bytes([plaintext[14], plaintext[15]]);
+        let mut plaintext_fixed = [0u8; 16];
+        plaintext_fixed.copy_from_slice(&plaintext[..16]);
+        Self {
+            plaintext: plaintext_fixed,
+            nonce,
+            routing_id,
+            encoded_tunnel_server_domain,
+        }
+    }
+}
+
+pub(crate) async fn await_advertisement(
+    eid_key: &[u8],
+) -> Result<(FidoDevice, DecryptedAdvert), Error> {
+    let uuids = &[
+        Uuid::parse_str(CABLE_UUID_FIDO).unwrap(),
+        Uuid::parse_str(CABLE_UUID_GOOGLE).unwrap(), // Deprecated, but may still be in use.
+    ];
+    let stream = btleplug::manager::start_discovery_for_service_data(uuids)
+        .await
+        .or(Err(Error::Transport(TransportError::TransportUnavailable)))?;
+
+    let mut stream = pin!(stream);
+    while let Some((adapter, peripheral, data)) = stream.as_mut().next().await {
+        debug!({ ?peripheral, ?data }, "Found device with service data");
+
+        let Some(device) = btleplug::manager::get_device(peripheral.clone())
+            .await
+            .or(Err(Error::Transport(TransportError::TransportUnavailable)))?
+        else {
+            warn!(
+                ?peripheral,
+                "Unable to fetch peripheral properties, ignoring"
+            );
+            continue;
+        };
+
+        trace!(?device, ?data, ?eid_key);
+        let Some(decrypted) = trial_decrypt_advert(&eid_key, &data) else {
+            warn!(?device, "Trial decrypt failed, ignoring");
+            continue;
+        };
+        trace!(?decrypted);
+
+        let advert = DecryptedAdvert::from(decrypted.as_slice());
+        debug!(
+            ?device,
+            ?decrypted,
+            "Successfully decrypted advertisement from device"
+        );
+
+        adapter
+            .stop_scan()
+            .await
+            .or(Err(Error::Transport(TransportError::TransportUnavailable)))?;
+
+        return Ok((device, advert));
+    }
+
+    warn!("BLE advertisement discovery stream terminated");
+    Err(Error::Transport(TransportError::TransportUnavailable))
+}

--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -22,8 +22,8 @@ use super::qr_code_device::CableQrCodeDevice;
 
 #[derive(Debug)]
 pub enum CableChannelDevice<'d> {
-    QrCode(&'d CableQrCodeDevice<'d>),
-    Known(&'d CableKnownDevice<'d>),
+    QrCode(&'d CableQrCodeDevice),
+    Known(&'d CableKnownDevice),
 }
 
 #[derive(Debug)]

--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -27,7 +27,7 @@ pub enum CableChannelDevice<'d> {
 }
 
 #[derive(Debug)]
-pub struct CableChannel<'d> {
+pub struct CableChannel {
     /// The WebSocket stream used for communication.
     // pub(crate) ws_stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
 
@@ -35,22 +35,20 @@ pub struct CableChannel<'d> {
     // pub(crate) noise_state: TransportState,
 
     /// The device that this channel is connected to.
-    pub device: CableChannelDevice<'d>,
-
     pub(crate) handle_connection: task::JoinHandle<()>,
     pub(crate) cbor_sender: mpsc::Sender<CborRequest>,
     pub(crate) cbor_receiver: mpsc::Receiver<CborResponse>,
     pub(crate) tx: mpsc::Sender<UxUpdate>,
 }
 
-impl Display for CableChannel<'_> {
+impl Display for CableChannel {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "CableChannel")
     }
 }
 
 #[async_trait]
-impl<'d> Channel for CableChannel<'d> {
+impl<'d> Channel for CableChannel {
     async fn supported_protocols(&self) -> Result<SupportedProtocols, Error> {
         Ok(SupportedProtocols::fido2_only())
     }
@@ -111,7 +109,7 @@ impl<'d> Channel for CableChannel<'d> {
     }
 }
 
-impl<'d> Ctap2AuthTokenStore for CableChannel<'d> {
+impl<'d> Ctap2AuthTokenStore for CableChannel {
     fn store_auth_data(&mut self, _auth_token_data: AuthTokenData) {}
 
     fn get_auth_data(&self) -> Option<&AuthTokenData> {

--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -47,6 +47,12 @@ impl Display for CableChannel {
     }
 }
 
+impl Drop for CableChannel {
+    fn drop(&mut self) {
+        self.handle_connection.abort();
+    }
+}
+
 #[async_trait]
 impl<'d> Channel for CableChannel {
     async fn supported_protocols(&self) -> Result<SupportedProtocols, Error> {

--- a/libwebauthn/src/transport/cable/crypto.rs
+++ b/libwebauthn/src/transport/cable/crypto.rs
@@ -28,7 +28,7 @@ fn reserved_bits_are_zero(plaintext: &[u8]) -> bool {
 }
 
 #[instrument]
-pub fn trial_decrypt_advert(eid_key: &[u8], candidate_advert: &[u8]) -> Option<Vec<u8>> {
+pub fn trial_decrypt_advert(eid_key: &[u8], candidate_advert: &[u8]) -> Option<[u8; 16]> {
     if candidate_advert.len() != 20 {
         warn!("candidate advert is not 20 bytes");
         return None;
@@ -55,7 +55,9 @@ pub fn trial_decrypt_advert(eid_key: &[u8], candidate_advert: &[u8]) -> Option<V
         return None;
     }
 
-    Some(block.to_vec())
+    let mut plaintext = [0u8; 16];
+    plaintext.copy_from_slice(&block);
+    Some(plaintext)
 }
 
 #[cfg(test)]

--- a/libwebauthn/src/transport/cable/crypto.rs
+++ b/libwebauthn/src/transport/cable/crypto.rs
@@ -13,12 +13,12 @@ pub enum KeyPurpose {
 }
 
 
-pub fn derive(secret: &[u8; 16], salt: Option<&[u8]>, purpose: KeyPurpose) -> Vec<u8> {
+pub fn derive(secret: &[u8], salt: Option<&[u8]>, purpose: KeyPurpose) -> [u8; 64] {
     let mut purpose32 = [0u8; 4];
     purpose32[0] = purpose as u8;
 
     let hkdf = Hkdf::<Sha256>::new(salt, secret);
-    let mut output = vec![0u8; 64];
+    let mut output = [0u8; 64];
     hkdf.expand(&purpose32, &mut output).unwrap();
     output
 }
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn derive_eidkey_nosalt() {
         let input: [u8; 16] = hex::decode("00112233445566778899aabbccddeeff").unwrap().try_into().unwrap();
-        let output = derive(&input, None, KeyPurpose::EIDKey);
+        let output = derive(&input, None, KeyPurpose::EIDKey).to_vec();
         let expected = hex::decode("efafab5b2c84a11c80e3ad0770353138b414a859ccd3afcc99e3d3250dba65084ede8e38e75432617c0ccae1ffe5d8143df0db0cd6d296f489419cd6411ee505").unwrap();
         assert_eq!(output, expected);
     }
@@ -75,7 +75,7 @@ mod tests {
     fn derive_eidkey_salt() {
         let input: [u8; 16] = hex::decode("00112233445566778899aabbccddeeff").unwrap().try_into().unwrap();
         let salt = hex::decode("ffeeddccbbaa998877665544332211").unwrap();
-        let output = derive(&input, Some(&salt), KeyPurpose::EIDKey);
+        let output = derive(&input, Some(&salt), KeyPurpose::EIDKey).to_vec();
         let expected = hex::decode("168cf3dd220a7907f8bac30f559be92a3b6d937fe5594beeaf1e50e35976b7d654dd550e22ae4c801b9d1cdbf0d2b1472daa1328661eb889acae3023b7ffa509").unwrap();
         assert_eq!(output, expected);
     }

--- a/libwebauthn/src/transport/cable/known_devices.rs
+++ b/libwebauthn/src/transport/cable/known_devices.rs
@@ -191,6 +191,7 @@ impl<'d> Device<'d, Cable, CableChannel> for CableKnownDevice {
         let noise_state = tunnel::do_handshake(&mut ws_stream, psk, &connection_type).await?;
 
         tunnel::channel(
+            &connection_type,
             noise_state,
             &self.device_info.tunnel_domain,
             &Some(self.store.clone()),
@@ -203,7 +204,7 @@ impl<'d> Device<'d, Cable, CableChannel> for CableKnownDevice {
 type ClientNonce = [u8; 16];
 
 // Key 3: either the string “ga” to hint that a getAssertion will follow, or “mc” to hint that a makeCredential will follow.
-#[derive(Debug, SerializeIndexed)]
+#[derive(Clone, Debug, SerializeIndexed)]
 #[serde(offset = 1)]
 pub struct ClientPayload {
     pub link_id: ByteBuf,

--- a/libwebauthn/src/transport/cable/known_devices.rs
+++ b/libwebauthn/src/transport/cable/known_devices.rs
@@ -125,7 +125,7 @@ unsafe impl Send for CableKnownDevice {}
 unsafe impl Sync for CableKnownDevice {}
 
 #[async_trait]
-impl<'d> Device<'d, Cable, CableChannel<'d>> for CableKnownDevice {
+impl<'d> Device<'d, Cable, CableChannel> for CableKnownDevice {
     async fn channel(&'d mut self) -> Result<(CableChannel, mpsc::Receiver<UxUpdate>), Error> {
         todo!()
     }

--- a/libwebauthn/src/transport/cable/known_devices.rs
+++ b/libwebauthn/src/transport/cable/known_devices.rs
@@ -1,77 +1,131 @@
+use std::collections::HashMap;
 use std::fmt::{Debug, Display};
+use std::sync::Arc;
 
 use crate::transport::error::Error;
 use crate::transport::Device;
+use crate::webauthn::TransportError;
 use crate::UxUpdate;
 
 use async_trait::async_trait;
+use futures::lock::Mutex;
 use tokio::sync::mpsc;
+use tracing::{debug, trace};
 
 use super::channel::CableChannel;
+use super::tunnel::CableLinkingInfo;
 use super::Cable;
 
 #[async_trait]
-pub trait CableKnownDeviceInfoStore: Debug + Send {
-    /// Called whenever a known device should be added.
-    async fn put_known_device(&mut self, device: &CableKnownDeviceInfo);
+pub trait CableKnownDeviceInfoStore: Debug + Send + Sync {
+    /// Called whenever a known device should be added or updated.
+    async fn put_known_device(&self, device_id: &CableKnownDeviceId, device: &CableKnownDeviceInfo);
     /// Called whenever a known device becomes permanently unavailable.
-    async fn delete_known_device(&mut self, device_id: String);
+    async fn delete_known_device(&self, device_id: &CableKnownDeviceId);
 }
 
-/// A no-op known-device store for ephemeral-only implementations.
+/// An in-memory store for testing purposes.
 #[derive(Debug, Default, Clone)]
 pub struct EphemeralDeviceInfoStore {
-    pub last_device_info: Option<CableKnownDeviceInfo>,
+    pub known_devices: Arc<Mutex<HashMap<CableKnownDeviceId, CableKnownDeviceInfo>>>,
+}
+
+impl EphemeralDeviceInfoStore {
+    pub fn new() -> Self {
+        Self {
+            known_devices: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
 }
 
 unsafe impl Send for EphemeralDeviceInfoStore {}
 
 #[async_trait]
 impl CableKnownDeviceInfoStore for EphemeralDeviceInfoStore {
-    async fn put_known_device(&mut self, device: &CableKnownDeviceInfo) {
-        self.last_device_info = Some(device.clone())
+    async fn put_known_device(
+        &self,
+        device_id: &CableKnownDeviceId,
+        device: &CableKnownDeviceInfo,
+    ) {
+        debug!(?device_id, "Inserting or updating known device");
+        trace!(?device);
+        let mut known_devices = self.known_devices.lock().await;
+        known_devices.insert(device_id.clone(), device.clone());
     }
 
-    async fn delete_known_device(&mut self, device_id: String) {
-        if let Some(last_device_info) = &self.last_device_info {
-            if last_device_info.device_id == device_id {
-                self.last_device_info = None
-            }
-        }
+    async fn delete_known_device(&self, device_id: &CableKnownDeviceId) {
+        debug!(?device_id, "Deleting known device");
+        let mut known_devices = self.known_devices.lock().await;
+        known_devices.remove(device_id);
     }
 }
 
+pub type CableKnownDeviceId = String;
+
 #[derive(Debug, Clone)]
 pub struct CableKnownDeviceInfo {
-    pub device_id: String,
     pub contact_id: Vec<u8>,
     pub link_id: [u8; 8],
     pub link_secret: [u8; 32],
     pub public_key: [u8; 65],
     pub name: String,
+    pub tunnel_domain: String,
+}
+
+impl From<&CableLinkingInfo> for CableKnownDeviceId {
+    fn from(linking_info: &CableLinkingInfo) -> Self {
+        hex::encode(&linking_info.authenticator_public_key)
+    }
+}
+
+impl CableKnownDeviceInfo {
+    pub(crate) fn new(tunnel_domain: &str, linking_info: &CableLinkingInfo) -> Result<Self, Error> {
+        let info = Self {
+            contact_id: linking_info.contact_id.to_vec(),
+            link_id: linking_info
+                .link_id
+                .clone()
+                .try_into()
+                .map_err(|_| Error::Transport(TransportError::InvalidFraming))?,
+            link_secret: linking_info
+                .link_secret
+                .clone()
+                .try_into()
+                .map_err(|_| Error::Transport(TransportError::InvalidFraming))?,
+            public_key: linking_info
+                .authenticator_public_key
+                .clone()
+                .try_into()
+                .map_err(|_| Error::Transport(TransportError::InvalidFraming))?,
+            name: linking_info.authenticator_name.clone(),
+            tunnel_domain: tunnel_domain.to_string(),
+        };
+        Ok(info)
+    }
 }
 
 #[derive(Debug)]
-pub struct CableKnownDevice<'d> {
+pub struct CableKnownDevice {
     pub device_info: CableKnownDeviceInfo,
-    _store: &'d mut Box<dyn CableKnownDeviceInfoStore>,
+    _store: Arc<dyn CableKnownDeviceInfoStore>,
 }
 
-impl<'d> Display for CableKnownDevice<'d> {
+impl Display for CableKnownDevice {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{} ({})",
-            self.device_info.name, self.device_info.device_id
+            &self.device_info.name,
+            hex::encode(&self.device_info.public_key)
         )
     }
 }
 
-unsafe impl<'d> Send for CableKnownDevice<'d> {}
-unsafe impl<'d> Sync for CableKnownDevice<'d> {}
+unsafe impl Send for CableKnownDevice {}
+unsafe impl Sync for CableKnownDevice {}
 
 #[async_trait]
-impl<'d> Device<'d, Cable, CableChannel<'d>> for CableKnownDevice<'d> {
+impl<'d> Device<'d, Cable, CableChannel<'d>> for CableKnownDevice {
     async fn channel(&'d mut self) -> Result<(CableChannel, mpsc::Receiver<UxUpdate>), Error> {
         todo!()
     }

--- a/libwebauthn/src/transport/cable/mod.rs
+++ b/libwebauthn/src/transport/cable/mod.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 mod crypto;
 mod digit_encode;
 
+pub mod advertisement;
 pub mod channel;
 pub mod known_devices;
 pub mod qr_code_device;

--- a/libwebauthn/src/transport/cable/qr_code_device.rs
+++ b/libwebauthn/src/transport/cable/qr_code_device.rs
@@ -243,8 +243,8 @@ impl Display for CableQrCodeDevice {
 }
 
 #[async_trait]
-impl<'d> Device<'d, Cable, CableChannel<'d>> for CableQrCodeDevice {
-    async fn channel(&'d mut self) -> Result<(CableChannel<'d>, mpsc::Receiver<UxUpdate>), Error> {
+impl<'d> Device<'d, Cable, CableChannel> for CableQrCodeDevice {
+    async fn channel(&'d mut self) -> Result<(CableChannel, mpsc::Receiver<UxUpdate>), Error> {
         let (_device, advert) = self.await_advertisement().await?;
 
         let Some(tunnel_domain) =
@@ -270,7 +270,7 @@ impl<'d> Device<'d, Cable, CableChannel<'d>> for CableQrCodeDevice {
             .unwrap();
 
         return tunnel::connect(
-            self,
+            &self.store,
             &tunnel_domain,
             &routing_id_str,
             &tunnel_id_str,

--- a/libwebauthn/src/transport/cable/qr_code_device.rs
+++ b/libwebauthn/src/transport/cable/qr_code_device.rs
@@ -1,10 +1,8 @@
 use std::fmt::{Debug, Display};
-use std::pin::pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 
 use async_trait::async_trait;
-use futures::StreamExt;
 use p256::elliptic_curve::sec1::ToEncodedPoint;
 use p256::{NonZeroScalar, SecretKey};
 use rand::rngs::OsRng;
@@ -13,22 +11,18 @@ use serde::Serialize;
 use serde_bytes::ByteArray;
 use serde_indexed::SerializeIndexed;
 use tokio::sync::mpsc;
-use tracing::{debug, error, trace, warn};
-use uuid::Uuid;
+use tracing::{debug, error};
 
 use super::known_devices::CableKnownDeviceInfoStore;
 use super::tunnel::{self, KNOWN_TUNNEL_DOMAINS};
 use super::{channel::CableChannel, Cable};
-use crate::transport::ble::btleplug::{self, FidoDevice};
-use crate::transport::cable::crypto::{derive, trial_decrypt_advert, KeyPurpose};
+use crate::transport::cable::advertisement::await_advertisement;
+use crate::transport::cable::crypto::{derive, KeyPurpose};
 use crate::transport::cable::digit_encode;
 use crate::transport::error::Error;
 use crate::transport::Device;
 use crate::webauthn::TransportError;
 use crate::UxUpdate;
-
-const CABLE_UUID_FIDO: &str = "0000fff9-0000-1000-8000-00805f9b34fb";
-const CABLE_UUID_GOOGLE: &str = "0000fde2-0000-1000-8000-00805f9b34fb";
 
 #[derive(Debug, Clone, Copy)]
 pub enum QrCodeOperationHint {
@@ -100,32 +94,6 @@ impl Debug for CableQrCodeDevice {
     }
 }
 
-#[derive(Debug)]
-struct DecryptedAdvert {
-    plaintext: [u8; 16],
-    nonce: [u8; 10],
-    routing_id: [u8; 3],
-    encoded_tunnel_server_domain: u16,
-}
-
-impl From<&[u8]> for DecryptedAdvert {
-    fn from(plaintext: &[u8]) -> Self {
-        let mut nonce = [0u8; 10];
-        nonce.copy_from_slice(&plaintext[1..11]);
-        let mut routing_id = [0u8; 3];
-        routing_id.copy_from_slice(&plaintext[11..14]);
-        let encoded_tunnel_server_domain = u16::from_le_bytes([plaintext[14], plaintext[15]]);
-        let mut plaintext_fixed = [0u8; 16];
-        plaintext_fixed.copy_from_slice(&plaintext[..16]);
-        Self {
-            plaintext: plaintext_fixed,
-            nonce,
-            routing_id,
-            encoded_tunnel_server_domain,
-        }
-    }
-}
-
 impl CableQrCodeDevice {
     /// Generates a QR code, linking the provided known-device store. A device scanning
     /// this QR code may be persisted to the store after a successful connection.
@@ -183,53 +151,6 @@ impl CableQrCodeDevice {
     pub fn new_transient(hint: QrCodeOperationHint) -> Self {
         Self::new(hint, false, None)
     }
-
-    async fn await_advertisement(&self) -> Result<(FidoDevice, DecryptedAdvert), Error> {
-        let uuids = &[
-            Uuid::parse_str(CABLE_UUID_FIDO).unwrap(),
-            Uuid::parse_str(CABLE_UUID_GOOGLE).unwrap(), // Deprecated, but may still be in use.
-        ];
-        let stream = btleplug::manager::start_discovery_for_service_data(uuids)
-            .await
-            .or(Err(Error::Transport(TransportError::TransportUnavailable)))?;
-
-        let mut stream = pin!(stream);
-        while let Some((peripheral, data)) = stream.as_mut().next().await {
-            debug!({ ?peripheral, ?data }, "Found device with service data");
-
-            let Some(device) = btleplug::manager::get_device(peripheral.clone())
-                .await
-                .or(Err(Error::Transport(TransportError::TransportUnavailable)))?
-            else {
-                warn!(
-                    ?peripheral,
-                    "Unable to fetch peripheral properties, ignoring"
-                );
-                continue;
-            };
-
-            let eid_key: Vec<u8> = derive(&self.qr_code.qr_secret, None, KeyPurpose::EIDKey);
-            trace!(?device, ?data, ?eid_key);
-
-            let Some(decrypted) = trial_decrypt_advert(&eid_key, &data) else {
-                warn!(?device, "Trial decrypt failed, ignoring");
-                continue;
-            };
-            trace!(?decrypted);
-
-            let advert = DecryptedAdvert::from(decrypted.as_slice());
-            debug!(
-                ?device,
-                ?decrypted,
-                "Successfully decrypted advertisement from device"
-            );
-
-            return Ok((device, advert));
-        }
-
-        warn!("BLE advertisement discovery stream terminated");
-        Err(Error::Transport(TransportError::TransportUnavailable))
-    }
 }
 
 unsafe impl Send for CableQrCodeDevice {}
@@ -245,7 +166,8 @@ impl Display for CableQrCodeDevice {
 #[async_trait]
 impl<'d> Device<'d, Cable, CableChannel> for CableQrCodeDevice {
     async fn channel(&'d mut self) -> Result<(CableChannel, mpsc::Receiver<UxUpdate>), Error> {
-        let (_device, advert) = self.await_advertisement().await?;
+        let eid_key: [u8; 64] = derive(self.qr_code.qr_secret.as_ref(), None, KeyPurpose::EIDKey);
+        let (_device, advert) = await_advertisement(&eid_key).await?;
 
         let Some(tunnel_domain) =
             tunnel::decode_tunnel_server_domain(advert.encoded_tunnel_server_domain)
@@ -258,26 +180,26 @@ impl<'d> Device<'d, Cable, CableChannel> for CableQrCodeDevice {
         let routing_id_str = hex::encode(&advert.routing_id);
         let _nonce_str = hex::encode(&advert.nonce);
 
-        let tunnel_id = &derive(&self.qr_code.qr_secret.as_ref(), None, KeyPurpose::TunnelID)[..16];
+        let tunnel_id = &derive(self.qr_code.qr_secret.as_ref(), None, KeyPurpose::TunnelID)[..16];
         let tunnel_id_str = hex::encode(&tunnel_id);
 
-        let psk: &[u8; 32] = &derive(
-            &self.qr_code.qr_secret.as_ref(),
-            Some(&advert.plaintext),
-            KeyPurpose::PSK,
-        )[..32]
-            .try_into()
-            .unwrap();
+        let mut psk: [u8; 32] = [0u8; 32];
+        psk.copy_from_slice(
+            &derive(
+                self.qr_code.qr_secret.as_ref(),
+                Some(&advert.plaintext),
+                KeyPurpose::PSK,
+            )[..32],
+        );
 
-        return tunnel::connect(
-            &self.store,
-            &tunnel_domain,
-            &routing_id_str,
-            &tunnel_id_str,
-            psk,
-            &self.private_key,
-        )
-        .await;
+        let connection_type = tunnel::CableTunnelConnectionType::QrCode {
+            routing_id: routing_id_str,
+            tunnel_id: tunnel_id_str.clone(),
+            private_key: self.private_key,
+        };
+        let mut ws_stream = tunnel::connect(&tunnel_domain, &connection_type).await?;
+        let noise_state = tunnel::do_handshake(&mut ws_stream, psk, &connection_type).await?;
+        tunnel::channel(noise_state, &tunnel_domain, &self.store, ws_stream).await
     }
 
     // #[instrument(skip_all)]

--- a/libwebauthn/src/transport/cable/qr_code_device.rs
+++ b/libwebauthn/src/transport/cable/qr_code_device.rs
@@ -24,22 +24,12 @@ use crate::transport::Device;
 use crate::webauthn::TransportError;
 use crate::UxUpdate;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
 pub enum QrCodeOperationHint {
+    #[serde(rename = "ga")]
     GetAssertionRequest,
+    #[serde(rename = "mc")]
     MakeCredential,
-}
-
-impl Serialize for QrCodeOperationHint {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            QrCodeOperationHint::GetAssertionRequest => serializer.serialize_str("ga"),
-            QrCodeOperationHint::MakeCredential => serializer.serialize_str("mc"),
-        }
-    }
 }
 
 #[derive(Debug, SerializeIndexed)]

--- a/libwebauthn/src/transport/cable/qr_code_device.rs
+++ b/libwebauthn/src/transport/cable/qr_code_device.rs
@@ -69,7 +69,7 @@ impl ToString for CableQrCode {
 pub struct CableQrCodeDevice {
     /// The QR code to be scanned by the new authenticator.
     pub qr_code: CableQrCode,
-    /// An ephemeral private, corresponding to the public key within the QR code.
+    /// An ephemeral private key, corresponding to the public key within the QR code.
     pub private_key: NonZeroScalar,
     /// An optional reference to the store. This may be None, if no persistence is desired.
     pub(crate) store: Option<Arc<dyn CableKnownDeviceInfoStore>>,
@@ -189,7 +189,14 @@ impl<'d> Device<'d, Cable, CableChannel> for CableQrCodeDevice {
         };
         let mut ws_stream = tunnel::connect(&tunnel_domain, &connection_type).await?;
         let noise_state = tunnel::do_handshake(&mut ws_stream, psk, &connection_type).await?;
-        tunnel::channel(noise_state, &tunnel_domain, &self.store, ws_stream).await
+        tunnel::channel(
+            &connection_type,
+            noise_state,
+            &tunnel_domain,
+            &self.store,
+            ws_stream,
+        )
+        .await
     }
 
     // #[instrument(skip_all)]

--- a/libwebauthn/src/transport/cable/tunnel.rs
+++ b/libwebauthn/src/transport/cable/tunnel.rs
@@ -108,7 +108,7 @@ pub(crate) struct CableLinkingInfo {
     pub authenticator_public_key: Vec<u8>,
     /// User-friendly name of the authenticator
     pub authenticator_name: String,
-    /// HMAC of the handshake hash (Noise's channel binding value) usinng the
+    /// HMAC of the handshake hash (Noise's channel binding value) using the
     /// shared secret (link_secret) as key
     #[allow(dead_code)]
     pub handshake_signature: Vec<u8>,

--- a/libwebauthn/src/transport/cable/tunnel.rs
+++ b/libwebauthn/src/transport/cable/tunnel.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use ctap_types::serde::cbor_deserialize;
-use ctap_types::serde::cbor_serialize;
 use futures::{SinkExt, StreamExt};
 use p256::NonZeroScalar;
 use serde::Deserialize;
@@ -13,7 +12,7 @@ use sha2::{Digest, Sha256};
 use snow::{Builder, TransportState};
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tokio::task::{self, JoinHandle};
+use tokio::task;
 use tokio_tungstenite::tungstenite::http::StatusCode;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
@@ -202,7 +201,9 @@ pub(crate) async fn connect<'d>(
                 .or(Err(Error::Transport(TransportError::InvalidEndpoint)))?,
         );
     }
-    let (mut ws_stream, response) = match connect_async(request).await {
+    trace!(?request);
+
+    let (ws_stream, response) = match connect_async(request).await {
         Ok((ws_stream, response)) => (ws_stream, response),
         Err(e) => {
             error!(?e, "Failed to connect to tunnel server");

--- a/libwebauthn/src/transport/cable/tunnel.rs
+++ b/libwebauthn/src/transport/cable/tunnel.rs
@@ -578,7 +578,7 @@ async fn connection_recv_update(message: &[u8]) -> Result<Option<CableLinkingInf
     };
 
     let Some(Value::Map(linking_info_map)) = update_message.get(&Value::Integer(0x01)) else {
-        warn!("Epty linking info map");
+        warn!("Empty linking info map");
         return Ok(None);
     };
 

--- a/libwebauthn/src/transport/error.rs
+++ b/libwebauthn/src/transport/error.rs
@@ -29,6 +29,8 @@ pub enum TransportError {
     TransportUnavailable,
     Timeout,
     UnknownDevice,
+    InvalidKey,
+    InvalidSignature,
 }
 
 impl std::error::Error for TransportError {}

--- a/libwebauthn/src/transport/error.rs
+++ b/libwebauthn/src/transport/error.rs
@@ -28,6 +28,7 @@ pub enum TransportError {
     NegotiationFailed,
     TransportUnavailable,
     Timeout,
+    UnknownDevice,
 }
 
 impl std::error::Error for TransportError {}


### PR DESCRIPTION
## Changes

* Updates internals of CableKnownDeviceInfoStore, to make it easier to use and thread-safe.
* Adds parsing of caBLE update messages. This includes a Google-specific key (999). Due to a limitation in serde-indexed, parsing of this structure has to be done field-by-field with `serde_cbor`. To be fixed properly with #66.
* Connect to known device from saved state.
* Verifies handshake signature. Note this currently only works for linking information received on QR-initiated transactions. The protocol doesn't seen to support subsequent updates, as the ephemeral QR-code identity key is needed for verification.