### PR TITLE
Allow unknown CBOR fields (ref #66)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "solo/src/ext"]
 	path = solo/src/ext
 	url = https://github.com/AlfioEmanueleFresta/solo.git
+[submodule "serde-indexed"]
+	path = serde-indexed
+	url = git@github.com:AlfioEmanueleFresta/serde-indexed.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
  "heapless-bytes",
  "iso7816",
  "serde",
- "serde-indexed",
+ "serde-indexed 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes",
  "serde_repr",
 ]
@@ -1021,6 +1021,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hidapi"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,7 +1353,7 @@ dependencies = [
  "qrcode",
  "rand",
  "serde",
- "serde-indexed",
+ "serde-indexed 0.1.1",
  "serde_bytes",
  "serde_cbor",
  "serde_derive",
@@ -2166,6 +2172,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-byte-array"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63213ee4ed648dbd87db6fa993d4275b46bfb4ddfd95b3756045007c2b28f742"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde-indexed"
+version = "0.1.1"
+dependencies = [
+ "heapless",
+ "hex-literal",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde-byte-array",
+ "serde_bytes",
+ "serde_cbor",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3.5"
 tokio = { version = "1.1.1", features = ["full"] }
 serde = "1.0.110"
 serde_cbor = "0.11.1"
-serde-indexed = "0.1.1"
+serde-indexed = { path = "../serde-indexed" }
 serde_derive = "1.0.123"
 serde_repr = "0.1.6"
 serde_bytes = "0.11.5"

--- a/libwebauthn/src/management/authenticator_config.rs
+++ b/libwebauthn/src/management/authenticator_config.rs
@@ -1,3 +1,4 @@
+use crate::proto::ctap2::cbor::CborSerialize;
 use crate::proto::ctap2::Ctap2ClientPinRequest;
 pub use crate::transport::error::{CtapError, Error};
 use crate::transport::Channel;
@@ -14,7 +15,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use serde_bytes::ByteBuf;
-use serde_cbor::ser::to_vec;
 use std::time::Duration;
 use tracing::info;
 
@@ -173,7 +173,7 @@ impl Ctap2UserVerifiableRequest for Ctap2AuthenticatorConfigRequest {
         data.push(0x0D);
         data.push(self.subcommand as u8);
         if self.subcommand == Ctap2AuthenticatorConfigCommand::SetMinPINLength {
-            data.extend(to_vec(&self.subcommand_params).unwrap());
+            data.extend((&self.subcommand_params).to_vec().unwrap());
         }
         let uv_auth_param = uv_proto.authenticate(uv_auth_token, &data);
         self.protocol = Some(uv_proto.version());

--- a/libwebauthn/src/management/bio_enrollment.rs
+++ b/libwebauthn/src/management/bio_enrollment.rs
@@ -1,3 +1,4 @@
+use crate::proto::ctap2::cbor::CborSerialize;
 use crate::{
     ops::webauthn::UserVerificationRequirement,
     pin::PinUvAuthProtocol,
@@ -17,7 +18,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use serde_bytes::ByteBuf;
-use serde_cbor::ser::to_vec;
 use std::time::Duration;
 use tracing::info;
 
@@ -213,7 +213,7 @@ where
         let remaining_samples = unwrap_field!(resp.remaining_samples);
         let template_id = unwrap_field!(resp.template_id).clone();
         let sample_status = unwrap_field!(resp.last_enroll_sample_status);
-        Ok((template_id.to_vec(), sample_status, remaining_samples))
+        Ok((template_id.to_vec()?, sample_status, remaining_samples))
     }
 
     async fn capture_next_bio_enrollment_sample(
@@ -295,7 +295,7 @@ impl Ctap2UserVerifiableRequest for Ctap2BioEnrollmentRequest {
         };
         // e.g. "Authenticator calls verify(pinUvAuthToken, fingerprint (0x01) || removeEnrollment (0x06) || subCommandParams, pinUvAuthParam)"
         if let Some(params) = &self.subcommand_params {
-            data.extend(to_vec(params).unwrap());
+            data.extend(params.to_vec().unwrap());
         }
         let uv_auth_param = uv_proto.authenticate(uv_auth_token, &data);
         self.protocol = Some(uv_proto.version());

--- a/libwebauthn/src/management/credential_management.rs
+++ b/libwebauthn/src/management/credential_management.rs
@@ -1,3 +1,4 @@
+use crate::proto::ctap2::cbor::CborSerialize;
 use crate::{
     ops::webauthn::UserVerificationRequirement,
     pin::PinUvAuthProtocol,
@@ -17,7 +18,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use serde_bytes::ByteBuf;
-use serde_cbor::ser::to_vec;
 use std::time::Duration;
 use tracing::info;
 
@@ -111,7 +111,7 @@ where
         Ok((
             Ctap2RPData::new(
                 unwrap_field!(resp.rp),
-                unwrap_field!(resp.rp_id_hash).to_vec(),
+                unwrap_field!(resp.rp_id_hash).to_vec()?,
             ),
             unwrap_field!(resp.total_rps),
         ))
@@ -138,7 +138,7 @@ where
         }?;
         Ok(Ctap2RPData::new(
             unwrap_field!(resp.rp),
-            unwrap_field!(resp.rp_id_hash).to_vec(),
+            unwrap_field!(resp.rp_id_hash).to_vec()?,
         ))
     }
 
@@ -282,7 +282,7 @@ impl Ctap2UserVerifiableRequest for Ctap2CredentialManagementRequest {
 
         // e.g. pinUvAuthParam (0x04): authenticate(pinUvAuthToken, enumerateCredentialsBegin (0x04) || subCommandParams).
         if let Some(params) = &self.subcommand_params {
-            data.extend(to_vec(params).unwrap());
+            data.extend(params.to_vec().unwrap());
         }
         let uv_auth_param = uv_proto.authenticate(uv_auth_token, &data);
         self.protocol = Some(uv_proto.version());

--- a/libwebauthn/src/ops/u2f.rs
+++ b/libwebauthn/src/ops/u2f.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use cosey as cose;
 use serde_bytes::ByteBuf;
-use serde_cbor::to_vec;
 use sha2::{Digest, Sha256};
 use tracing::{error, trace};
 use x509_parser::nom::AsBytes;
@@ -14,6 +13,7 @@ use crate::ops::webauthn::{
 };
 use crate::proto::ctap1::{Ctap1RegisterRequest, Ctap1SignRequest};
 use crate::proto::ctap1::{Ctap1RegisterResponse, Ctap1SignResponse};
+use crate::proto::ctap2::cbor::CborSerialize;
 use crate::proto::ctap2::{
     Ctap2AttestationStatement, Ctap2COSEAlgorithmIdentifier, Ctap2GetAssertionResponse,
     Ctap2MakeCredentialResponse, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialType,
@@ -79,7 +79,7 @@ impl UpgradableResponse<MakeCredentialResponse, MakeCredentialRequest> for Regis
             x: x.into(),
             y: y.into(),
         });
-        let cose_encoded_public_key = to_vec(&cose_public_key).unwrap();
+        let cose_encoded_public_key = cose_public_key.to_vec()?;
         assert!(cose_encoded_public_key.len() == 77);
 
         // Let attestedCredData be a byte string with following structure:

--- a/libwebauthn/src/proto/ctap2/cbor/mod.rs
+++ b/libwebauthn/src/proto/ctap2/cbor/mod.rs
@@ -1,5 +1,7 @@
 mod request;
 mod response;
+mod serde;
 
 pub use request::CborRequest;
 pub use response::CborResponse;
+pub(crate) use serde::{CborDeserialize, CborError, CborSerialize};

--- a/libwebauthn/src/proto/ctap2/cbor/request.rs
+++ b/libwebauthn/src/proto/ctap2/cbor/request.rs
@@ -1,9 +1,6 @@
-extern crate serde_cbor;
-
-use serde_cbor::ser::to_vec;
-
 use std::io::Error as IOError;
 
+use crate::proto::ctap2::cbor::CborSerialize;
 use crate::proto::ctap2::model::Ctap2ClientPinRequest;
 use crate::proto::ctap2::model::Ctap2CommandCode;
 use crate::proto::ctap2::model::Ctap2GetAssertionRequest;
@@ -43,7 +40,7 @@ impl From<&Ctap2MakeCredentialRequest> for CborRequest {
     fn from(request: &Ctap2MakeCredentialRequest) -> CborRequest {
         CborRequest {
             command: Ctap2CommandCode::AuthenticatorMakeCredential,
-            encoded_data: to_vec(request).unwrap(),
+            encoded_data: request.to_vec().unwrap(),
         }
     }
 }
@@ -52,7 +49,7 @@ impl From<&Ctap2GetAssertionRequest> for CborRequest {
     fn from(request: &Ctap2GetAssertionRequest) -> CborRequest {
         CborRequest {
             command: Ctap2CommandCode::AuthenticatorGetAssertion,
-            encoded_data: to_vec(request).unwrap(),
+            encoded_data: request.to_vec().unwrap(),
         }
     }
 }
@@ -61,7 +58,7 @@ impl From<&Ctap2ClientPinRequest> for CborRequest {
     fn from(request: &Ctap2ClientPinRequest) -> CborRequest {
         CborRequest {
             command: Ctap2CommandCode::AuthenticatorClientPin,
-            encoded_data: to_vec(request).unwrap(),
+            encoded_data: request.to_vec().unwrap(),
         }
     }
 }
@@ -70,7 +67,7 @@ impl From<&Ctap2AuthenticatorConfigRequest> for CborRequest {
     fn from(request: &Ctap2AuthenticatorConfigRequest) -> CborRequest {
         CborRequest {
             command: Ctap2CommandCode::AuthenticatorConfig,
-            encoded_data: to_vec(request).unwrap(),
+            encoded_data: request.to_vec().unwrap(),
         }
     }
 }
@@ -84,7 +81,7 @@ impl From<&Ctap2BioEnrollmentRequest> for CborRequest {
         };
         CborRequest {
             command,
-            encoded_data: to_vec(request).unwrap(),
+            encoded_data: request.to_vec().unwrap(),
         }
     }
 }
@@ -98,7 +95,7 @@ impl From<&Ctap2CredentialManagementRequest> for CborRequest {
         };
         CborRequest {
             command,
-            encoded_data: to_vec(request).unwrap(),
+            encoded_data: request.to_vec().unwrap(),
         }
     }
 }

--- a/libwebauthn/src/proto/ctap2/cbor/serde.rs
+++ b/libwebauthn/src/proto/ctap2/cbor/serde.rs
@@ -1,0 +1,75 @@
+use serde::Serialize;
+
+#[derive(thiserror::Error, Debug)]
+pub enum CborError {
+    #[error("serde_cbor serialization error: {0}")]
+    SerdeCbor(#[from] serde_cbor::Error),
+}
+
+impl PartialEq for CborError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (CborError::SerdeCbor(e1), CborError::SerdeCbor(e2)) => {
+                e1.to_string() == e2.to_string()
+            }
+        }
+    }
+}
+
+pub(crate) trait CborSerialize {
+    fn to_vec(&self) -> Result<Vec<u8>, CborError>;
+}
+
+impl<T> CborSerialize for T
+where
+    T: Serialize,
+{
+    fn to_vec(&self) -> Result<Vec<u8>, CborError> {
+        serde_cbor::ser::to_vec(self).map_err(CborError::from)
+    }
+}
+
+pub(crate) trait CborDeserialize<T>: Sized + serde::de::DeserializeOwned {
+    fn from_reader<R: std::io::Read>(reader: R) -> Result<Self, CborError>;
+    fn from_slice(slice: &[u8]) -> Result<Self, CborError>;
+}
+
+impl<T> CborDeserialize<T> for T
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    fn from_reader<R: std::io::Read>(reader: R) -> Result<Self, CborError> {
+        serde_cbor::de::from_reader(reader).map_err(CborError::from)
+    }
+
+    fn from_slice(slice: &[u8]) -> Result<Self, CborError> {
+        serde_cbor::de::from_slice(slice).map_err(CborError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_indexed::{DeserializeIndexed, SerializeIndexed};
+
+    #[derive(Debug, PartialEq, SerializeIndexed, DeserializeIndexed)]
+    #[serde_indexed(offset = 1)]
+    struct TestStruct {
+        pub a: u8,
+        pub b: u8,
+    }
+
+    #[test]
+    fn test_deserialize_indexed_with_extra_field() {
+        // Map: 1 => 10, 2 => 20, 3 => 99 (unexpected)
+        let value = TestStruct { a: 10, b: 20 };
+        let mut map = std::collections::BTreeMap::new();
+        map.insert(1, 10u8);
+        map.insert(2, 20u8);
+        map.insert(3, 99u8); // unexpected field
+
+        let cbor = map.to_vec().unwrap();
+        let result = TestStruct::from_slice(&cbor).unwrap();
+        assert_eq!(result, value);
+    }
+}

--- a/libwebauthn/src/proto/ctap2/model.rs
+++ b/libwebauthn/src/proto/ctap2/model.rs
@@ -209,35 +209,35 @@ pub enum Ctap2UserVerificationOperation {
 
 #[cfg(test)]
 mod tests {
+    use crate::proto::ctap2::cbor::CborSerialize;
     use crate::proto::ctap2::Ctap2PublicKeyCredentialDescriptor;
 
-    use super::{Ctap2CredentialType, Ctap2COSEAlgorithmIdentifier, Ctap2PublicKeyCredentialType};
-    use serde_bytes::ByteBuf;
-    use serde_cbor;
+    use super::{Ctap2COSEAlgorithmIdentifier, Ctap2CredentialType, Ctap2PublicKeyCredentialType};
     use hex;
+    use serde_bytes::ByteBuf;
 
     #[test]
-    /// Verify CBOR serialization conforms to CTAP canonical standard, including ordering (see #95) 
+    /// Verify CBOR serialization conforms to CTAP canonical standard, including ordering (see #95)
     pub fn credential_type_field_serialization() {
         let credential_type = Ctap2CredentialType {
             algorithm: Ctap2COSEAlgorithmIdentifier::ES256,
             public_key_type: Ctap2PublicKeyCredentialType::PublicKey,
         };
-        let serialized = serde_cbor::to_vec(&credential_type).unwrap();
+        let serialized = credential_type.to_vec().unwrap();
         // Known good, verified by hand with cbor.me playground
         let expected = hex::decode("a263616c672664747970656a7075626c69632d6b6579").unwrap();
         assert_eq!(serialized, expected);
     }
 
     #[test]
-    /// Verify CBOR serialization conforms to CTAP canonical standard, including ordering (see #95) 
+    /// Verify CBOR serialization conforms to CTAP canonical standard, including ordering (see #95)
     pub fn credential_descriptor_serialization() {
         let credential_descriptor = Ctap2PublicKeyCredentialDescriptor {
             id: ByteBuf::from(vec![0x42]),
             r#type: Ctap2PublicKeyCredentialType::PublicKey,
             transports: None,
         };
-        let serialized = serde_cbor::to_vec(&credential_descriptor).unwrap();
+        let serialized = credential_descriptor.to_vec().unwrap();
         // Known good, verified by hand with cbor.me playground
         let expected = hex::decode("a2626964414264747970656a7075626c69632d6b6579").unwrap();
         assert_eq!(serialized, expected);

--- a/libwebauthn/src/proto/ctap2/model/get_assertion.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_assertion.rs
@@ -11,6 +11,8 @@ use crate::{
     webauthn::{Error, PlatformError},
 };
 
+use crate::proto::ctap2::cbor::CborSerialize;
+
 use super::{
     Ctap2AuthTokenPermissionRole, Ctap2COSEAlgorithmIdentifier, Ctap2GetInfoResponse,
     Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialUserEntity,
@@ -247,7 +249,7 @@ impl Ctap2GetAssertionRequestExtensions {
         // saltEnc(0x02): Encryption of the one or two salts (called salt1 (32 bytes) and salt2 (32 bytes)) using the shared secret as follows:
         //     One salt case: encrypt(shared secret, salt1)
         //     Two salt case: encrypt(shared secret, salt1 || salt2)
-        let mut salts = input.salt1.to_vec();
+        let mut salts = input.salt1.to_vec()?;
         if let Some(salt2) = input.salt2 {
             salts.extend(salt2);
         }

--- a/libwebauthn/src/proto/ctap2/protocol.rs
+++ b/libwebauthn/src/proto/ctap2/protocol.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use serde_cbor::from_slice;
 use tracing::{debug, instrument, trace, warn};
 
+use crate::proto::ctap2::cbor::CborDeserialize;
 use crate::proto::ctap2::cbor::CborRequest;
 use crate::proto::ctap2::{Ctap2BioEnrollmentResponse, Ctap2CommandCode};
 use crate::transport::error::{CtapError, Error, PlatformError};
@@ -22,7 +22,7 @@ const TIMEOUT_GET_INFO: Duration = Duration::from_millis(250);
 
 macro_rules! parse_cbor {
     ($type:ty, $data:expr) => {{
-        match from_slice::<$type>($data) {
+        match CborDeserialize::<$type>::from_slice($data) {
             Ok(f) => f,
             Err(e) => {
                 tracing::error!(

--- a/libwebauthn/src/transport/cable/qr_code_device.rs
+++ b/libwebauthn/src/transport/cable/qr_code_device.rs
@@ -16,6 +16,7 @@ use tracing::{debug, error};
 use super::known_devices::CableKnownDeviceInfoStore;
 use super::tunnel::{self, KNOWN_TUNNEL_DOMAINS};
 use super::{channel::CableChannel, Cable};
+use crate::proto::ctap2::cbor::CborSerialize;
 use crate::transport::cable::advertisement::await_advertisement;
 use crate::transport::cable::crypto::{derive, KeyPurpose};
 use crate::transport::cable::digit_encode;
@@ -59,7 +60,7 @@ pub struct CableQrCode {
 
 impl ToString for CableQrCode {
     fn to_string(&self) -> String {
-        let serialized = serde_cbor::to_vec(self).unwrap();
+        let serialized = self.to_vec().unwrap();
         format!("FIDO:/{}", digit_encode(&serialized))
     }
 }

--- a/libwebauthn/src/transport/cable/tunnel.rs
+++ b/libwebauthn/src/transport/cable/tunnel.rs
@@ -24,6 +24,7 @@ use tungstenite::client::IntoClientRequest;
 use super::channel::CableChannel;
 use super::known_devices::ClientPayload;
 use super::known_devices::{CableKnownDeviceInfo, CableKnownDeviceInfoStore};
+use crate::proto::ctap2::cbor::CborSerialize;
 use crate::proto::ctap2::cbor::{CborRequest, CborResponse};
 use crate::proto::ctap2::{Ctap2CommandCode, Ctap2GetInfoResponse};
 use crate::transport::cable::known_devices::CableKnownDeviceId;
@@ -584,7 +585,7 @@ async fn connection_recv_initial(
         }
     };
 
-    Ok(initial_message.info.to_vec())
+    Ok(initial_message.info.to_vec()?)
 }
 
 async fn connection_recv_update(message: &[u8]) -> Result<Option<CableLinkingInfo>, Error> {
@@ -682,7 +683,7 @@ async fn connection_recv(
         }
         CableTunnelMessageType::Ctap => {
             // Handle the CTAP message
-            let cbor_response: CborResponse = (&cable_message.payload.to_vec())
+            let cbor_response: CborResponse = (&cable_message.payload.to_vec()?)
                 .try_into()
                 .or(Err(TransportError::InvalidFraming))?;
 

--- a/libwebauthn/src/transport/error.rs
+++ b/libwebauthn/src/transport/error.rs
@@ -1,3 +1,4 @@
+use crate::proto::ctap2::cbor::CborError;
 pub use crate::proto::CtapError;
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -16,6 +17,8 @@ pub enum PlatformError {
     NotSupported,
     #[error("syntax error")]
     SyntaxError,
+    #[error("cbor serialization error: {0}")]
+    CborError(#[from] CborError),
 }
 
 #[derive(thiserror::Error, Debug, PartialEq)]
@@ -55,5 +58,11 @@ pub enum Error {
 impl From<snow::Error> for Error {
     fn from(_error: snow::Error) -> Self {
         Error::Transport(TransportError::NegotiationFailed)
+    }
+}
+
+impl From<CborError> for Error {
+    fn from(error: CborError) -> Self {
+        Error::Platform(PlatformError::CborError(error))
     }
 }


### PR DESCRIPTION
* Part fixes #66 for unknown CBOR structures decoded via DeserializeIndexed from serde-indexed.
* Remaining to allow unknown enum variants, to be fixed in a later PR.
 
Depends on https://github.com/trussed-dev/serde-indexed/pull/19.