### PR TITLE
Remove leftover serde_indexed-macros

### DIFF
--- a/libwebauthn/src/proto/ctap2/model/bio_enrollment.rs
+++ b/libwebauthn/src/proto/ctap2/model/bio_enrollment.rs
@@ -5,7 +5,6 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::time::Duration;
 
 #[derive(Debug, Clone, SerializeIndexed)]
-#[serde_indexed(offset = 1)]
 pub struct Ctap2BioEnrollmentRequest {
     // modality (0x01) 	Unsigned Integer 	Optional 	The user verification modality being requested
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/libwebauthn/src/proto/ctap2/model/client_pin.rs
+++ b/libwebauthn/src/proto/ctap2/model/client_pin.rs
@@ -6,7 +6,6 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use crate::pin::{PinUvAuthProtocol, PinUvAuthProtocolOne, PinUvAuthProtocolTwo};
 
 #[derive(Debug, Clone, SerializeIndexed)]
-#[serde_indexed(offset = 1)]
 pub struct Ctap2ClientPinRequest {
     ///pinUvAuthProtocol (0x01)
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
I'm not entirely sure what exactly caused the problem inside serde_indexed, but these macros (particularly the one at `Ctap2GetClientPinRequest`) caused my YubikeyBIO to error out, in the PIN case with `InvalidCborType` when trying to establish a shared secret.