### PR TITLE
Return U2F attestation statement in a way that does not require error checking in clients

### DIFF
--- a/libwebauthn/src/ops/u2f.rs
+++ b/libwebauthn/src/ops/u2f.rs
@@ -15,9 +15,8 @@ use crate::proto::ctap1::{Ctap1RegisterRequest, Ctap1SignRequest};
 use crate::proto::ctap1::{Ctap1RegisterResponse, Ctap1SignResponse};
 use crate::proto::ctap2::cbor;
 use crate::proto::ctap2::{
-    Ctap2AttestationStatement, Ctap2COSEAlgorithmIdentifier, Ctap2GetAssertionResponse,
-    Ctap2MakeCredentialResponse, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialType,
-    FidoU2fAttestationStmt,
+    Ctap2AttestationStatement, Ctap2GetAssertionResponse, Ctap2MakeCredentialResponse,
+    Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialType, FidoU2fAttestationStmt,
 };
 use crate::webauthn::{CtapError, Error};
 
@@ -132,9 +131,8 @@ impl UpgradableResponse<MakeCredentialResponse, MakeCredentialRequest> for Regis
         //   Note: An ASN.1-encoded ECDSA signature value ranges over 8–72 bytes in length. [U2FRawMsgs] incorrectly
         //   states a different length range.
         let attestation_statement = Ctap2AttestationStatement::FidoU2F(FidoU2fAttestationStmt {
-            algorithm: Ctap2COSEAlgorithmIdentifier::ES256,
             signature: ByteBuf::from(self.signature.clone()),
-            certificates: vec![ByteBuf::from(self.attestation.clone())],
+            certificate: ByteBuf::from(self.attestation.clone()),
         });
 
         // Let attestationObject be a CBOR map (see "attObj" in Generating an Attestation Object [WebAuthn]) with the

--- a/libwebauthn/src/proto/ctap2/model/get_assertion.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_assertion.rs
@@ -57,14 +57,11 @@ pub struct PackedAttestationStmt {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct FidoU2fAttestationStmt {
-    #[serde(rename = "alg")]
-    pub algorithm: Ctap2COSEAlgorithmIdentifier,
-
     #[serde(rename = "sig")]
     pub signature: ByteBuf,
 
     #[serde(rename = "x5c")]
-    pub certificates: Vec<ByteBuf>,
+    pub certificate: ByteBuf,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
We don't serialize these, so it's up to the application to repackage it. Since a single certificate is required by the standard, let's only return exactly one, removing the need to error check the length on the outside. The algorithm is also not needed.