### PR TITLE
Implement discoverable credential 'preferred'

### DIFF
--- a/libwebauthn/examples/webauthn_cable.rs
+++ b/libwebauthn/examples/webauthn_cable.rs
@@ -18,8 +18,7 @@ use tokio::time::sleep;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    DiscoverableCredentialRequirement, GetAssertionRequest, MakeCredentialRequest,
-    UserVerificationRequirement,
+    GetAssertionRequest, MakeCredentialRequest, ResidentKeyRequirement, UserVerificationRequirement,
 };
 use libwebauthn::proto::ctap2::{
     Ctap2CredentialType, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
@@ -113,7 +112,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             hash: Vec::from(challenge),
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-            discoverable_credential: Some(DiscoverableCredentialRequirement::Discouraged),
+            resident_key: Some(ResidentKeyRequirement::Discouraged),
             user_verification: UserVerificationRequirement::Preferred,
             algorithms: vec![Ctap2CredentialType::default()],
             exclude: None,

--- a/libwebauthn/examples/webauthn_cable.rs
+++ b/libwebauthn/examples/webauthn_cable.rs
@@ -18,7 +18,8 @@ use tokio::time::sleep;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    GetAssertionRequest, MakeCredentialRequest, UserVerificationRequirement,
+    DiscoverableCredentialRequirement, GetAssertionRequest, MakeCredentialRequest,
+    UserVerificationRequirement,
 };
 use libwebauthn::proto::ctap2::{
     Ctap2CredentialType, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
@@ -112,7 +113,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             hash: Vec::from(challenge),
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-            require_resident_key: false,
+            discoverable_credential: Some(DiscoverableCredentialRequirement::Discouraged),
             user_verification: UserVerificationRequirement::Preferred,
             algorithms: vec![Ctap2CredentialType::default()],
             exclude: None,

--- a/libwebauthn/examples/webauthn_extensions_hid.rs
+++ b/libwebauthn/examples/webauthn_extensions_hid.rs
@@ -10,10 +10,10 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    CredentialProtectionExtension, CredentialProtectionPolicy, GetAssertionHmacOrPrfInput,
-    GetAssertionRequest, GetAssertionRequestExtensions, HMACGetSecretInput,
-    MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension, MakeCredentialRequest,
-    MakeCredentialsRequestExtensions, UserVerificationRequirement,
+    CredentialProtectionExtension, CredentialProtectionPolicy, DiscoverableCredentialRequirement,
+    GetAssertionHmacOrPrfInput, GetAssertionRequest, GetAssertionRequestExtensions,
+    HMACGetSecretInput, MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension,
+    MakeCredentialRequest, MakeCredentialsRequestExtensions, UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -108,7 +108,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             hash: Vec::from(challenge),
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-            require_resident_key: true,
+            discoverable_credential: Some(DiscoverableCredentialRequirement::Required),
             user_verification: UserVerificationRequirement::Preferred,
             algorithms: vec![Ctap2CredentialType::default()],
             exclude: None,

--- a/libwebauthn/examples/webauthn_extensions_hid.rs
+++ b/libwebauthn/examples/webauthn_extensions_hid.rs
@@ -10,10 +10,10 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    CredentialProtectionExtension, CredentialProtectionPolicy, DiscoverableCredentialRequirement,
-    GetAssertionHmacOrPrfInput, GetAssertionRequest, GetAssertionRequestExtensions,
-    HMACGetSecretInput, MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension,
-    MakeCredentialRequest, MakeCredentialsRequestExtensions, UserVerificationRequirement,
+    CredentialProtectionExtension, CredentialProtectionPolicy, GetAssertionHmacOrPrfInput,
+    GetAssertionRequest, GetAssertionRequestExtensions, HMACGetSecretInput,
+    MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension, MakeCredentialRequest,
+    MakeCredentialsRequestExtensions, ResidentKeyRequirement, UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -108,7 +108,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             hash: Vec::from(challenge),
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-            discoverable_credential: Some(DiscoverableCredentialRequirement::Required),
+            resident_key: Some(ResidentKeyRequirement::Required),
             user_verification: UserVerificationRequirement::Preferred,
             algorithms: vec![Ctap2CredentialType::default()],
             exclude: None,

--- a/libwebauthn/examples/webauthn_hid.rs
+++ b/libwebauthn/examples/webauthn_hid.rs
@@ -10,8 +10,7 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    DiscoverableCredentialRequirement, GetAssertionRequest, MakeCredentialRequest,
-    UserVerificationRequirement,
+    GetAssertionRequest, MakeCredentialRequest, ResidentKeyRequirement, UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -92,7 +91,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             hash: Vec::from(challenge),
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-            discoverable_credential: Some(DiscoverableCredentialRequirement::Discouraged),
+            resident_key: Some(ResidentKeyRequirement::Discouraged),
             user_verification: UserVerificationRequirement::Preferred,
             algorithms: vec![Ctap2CredentialType::default()],
             exclude: None,

--- a/libwebauthn/examples/webauthn_hid.rs
+++ b/libwebauthn/examples/webauthn_hid.rs
@@ -10,7 +10,8 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    GetAssertionRequest, MakeCredentialRequest, UserVerificationRequirement,
+    DiscoverableCredentialRequirement, GetAssertionRequest, MakeCredentialRequest,
+    UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -91,7 +92,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             hash: Vec::from(challenge),
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-            require_resident_key: false,
+            discoverable_credential: Some(DiscoverableCredentialRequirement::Discouraged),
             user_verification: UserVerificationRequirement::Preferred,
             algorithms: vec![Ctap2CredentialType::default()],
             exclude: None,

--- a/libwebauthn/examples/webauthn_preflight_hid.rs
+++ b/libwebauthn/examples/webauthn_preflight_hid.rs
@@ -12,7 +12,8 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    GetAssertionRequest, GetAssertionResponse, MakeCredentialRequest, UserVerificationRequirement,
+    DiscoverableCredentialRequirement, GetAssertionRequest, GetAssertionResponse,
+    MakeCredentialRequest, UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -164,7 +165,7 @@ async fn make_credential_call(
         hash: Vec::from(challenge),
         relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
         user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-        require_resident_key: false,
+        discoverable_credential: Some(DiscoverableCredentialRequirement::Discouraged),
         user_verification: UserVerificationRequirement::Preferred,
         algorithms: vec![Ctap2CredentialType::default()],
         exclude: exclude_list,

--- a/libwebauthn/examples/webauthn_preflight_hid.rs
+++ b/libwebauthn/examples/webauthn_preflight_hid.rs
@@ -12,8 +12,8 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    DiscoverableCredentialRequirement, GetAssertionRequest, GetAssertionResponse,
-    MakeCredentialRequest, UserVerificationRequirement,
+    GetAssertionRequest, GetAssertionResponse, MakeCredentialRequest, ResidentKeyRequirement,
+    UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -165,7 +165,7 @@ async fn make_credential_call(
         hash: Vec::from(challenge),
         relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
         user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-        discoverable_credential: Some(DiscoverableCredentialRequirement::Discouraged),
+        resident_key: Some(ResidentKeyRequirement::Discouraged),
         user_verification: UserVerificationRequirement::Preferred,
         algorithms: vec![Ctap2CredentialType::default()],
         exclude: exclude_list,

--- a/libwebauthn/examples/webauthn_prf_hid.rs
+++ b/libwebauthn/examples/webauthn_prf_hid.rs
@@ -12,9 +12,9 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    GetAssertionHmacOrPrfInput, GetAssertionRequest, GetAssertionRequestExtensions,
-    MakeCredentialHmacOrPrfInput, MakeCredentialRequest, MakeCredentialsRequestExtensions,
-    PRFValue, UserVerificationRequirement,
+    DiscoverableCredentialRequirement, GetAssertionHmacOrPrfInput, GetAssertionRequest,
+    GetAssertionRequestExtensions, MakeCredentialHmacOrPrfInput, MakeCredentialRequest,
+    MakeCredentialsRequestExtensions, PRFValue, UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -102,7 +102,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             hash: Vec::from(challenge),
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-            require_resident_key: true,
+            discoverable_credential: Some(DiscoverableCredentialRequirement::Required),
             user_verification: UserVerificationRequirement::Preferred,
             algorithms: vec![Ctap2CredentialType::default()],
             exclude: None,

--- a/libwebauthn/examples/webauthn_prf_hid.rs
+++ b/libwebauthn/examples/webauthn_prf_hid.rs
@@ -12,9 +12,9 @@ use tokio::sync::mpsc::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    DiscoverableCredentialRequirement, GetAssertionHmacOrPrfInput, GetAssertionRequest,
-    GetAssertionRequestExtensions, MakeCredentialHmacOrPrfInput, MakeCredentialRequest,
-    MakeCredentialsRequestExtensions, PRFValue, UserVerificationRequirement,
+    GetAssertionHmacOrPrfInput, GetAssertionRequest, GetAssertionRequestExtensions,
+    MakeCredentialHmacOrPrfInput, MakeCredentialRequest, MakeCredentialsRequestExtensions,
+    PRFValue, ResidentKeyRequirement, UserVerificationRequirement,
 };
 use libwebauthn::pin::PinRequestReason;
 use libwebauthn::proto::ctap2::{
@@ -102,7 +102,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             hash: Vec::from(challenge),
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
-            discoverable_credential: Some(DiscoverableCredentialRequirement::Required),
+            resident_key: Some(ResidentKeyRequirement::Required),
             user_verification: UserVerificationRequirement::Preferred,
             algorithms: vec![Ctap2CredentialType::default()],
             exclude: None,

--- a/libwebauthn/src/ops/webauthn.rs
+++ b/libwebauthn/src/ops/webauthn.rs
@@ -12,9 +12,10 @@ pub use get_assertion::{
 };
 pub use make_credential::{
     CredentialPropsExtension, CredentialProtectionExtension, CredentialProtectionPolicy,
-    MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension,
-    MakeCredentialLargeBlobExtensionOutput, MakeCredentialPrfOutput, MakeCredentialRequest,
-    MakeCredentialResponse, MakeCredentialsRequestExtensions, MakeCredentialsResponseExtensions,
+    DiscoverableCredentialRequirement, MakeCredentialHmacOrPrfInput,
+    MakeCredentialLargeBlobExtension, MakeCredentialLargeBlobExtensionOutput,
+    MakeCredentialPrfOutput, MakeCredentialRequest, MakeCredentialResponse,
+    MakeCredentialsRequestExtensions, MakeCredentialsResponseExtensions,
     MakeCredentialsResponseUnsignedExtensions,
 };
 
@@ -51,7 +52,8 @@ pub trait DowngradableRequest<T> {
 #[cfg(test)]
 mod tests {
     use crate::ops::webauthn::{
-        DowngradableRequest, MakeCredentialRequest, UserVerificationRequirement,
+        DiscoverableCredentialRequirement, DowngradableRequest, MakeCredentialRequest,
+        UserVerificationRequirement,
     };
     use crate::proto::ctap2::{
         Ctap2COSEAlgorithmIdentifier, Ctap2CredentialType, Ctap2PublicKeyCredentialType,
@@ -61,7 +63,7 @@ mod tests {
     fn ctap2_make_credential_downgradable() {
         let mut request = MakeCredentialRequest::dummy();
         request.algorithms = vec![Ctap2CredentialType::default()];
-        request.require_resident_key = false;
+        request.discoverable_credential = Some(DiscoverableCredentialRequirement::Discouraged);
         assert!(request.is_downgradable());
     }
 
@@ -69,7 +71,7 @@ mod tests {
     fn ctap2_make_credential_downgradable_unsupported_rk() {
         let mut request = MakeCredentialRequest::dummy();
         request.algorithms = vec![Ctap2CredentialType::default()];
-        request.require_resident_key = true;
+        request.discoverable_credential = Some(DiscoverableCredentialRequirement::Required);
         assert!(!request.is_downgradable());
     }
 

--- a/libwebauthn/src/ops/webauthn.rs
+++ b/libwebauthn/src/ops/webauthn.rs
@@ -12,11 +12,10 @@ pub use get_assertion::{
 };
 pub use make_credential::{
     CredentialPropsExtension, CredentialProtectionExtension, CredentialProtectionPolicy,
-    DiscoverableCredentialRequirement, MakeCredentialHmacOrPrfInput,
-    MakeCredentialLargeBlobExtension, MakeCredentialLargeBlobExtensionOutput,
-    MakeCredentialPrfOutput, MakeCredentialRequest, MakeCredentialResponse,
-    MakeCredentialsRequestExtensions, MakeCredentialsResponseExtensions,
-    MakeCredentialsResponseUnsignedExtensions,
+    MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension,
+    MakeCredentialLargeBlobExtensionOutput, MakeCredentialPrfOutput, MakeCredentialRequest,
+    MakeCredentialResponse, MakeCredentialsRequestExtensions, MakeCredentialsResponseExtensions,
+    MakeCredentialsResponseUnsignedExtensions, ResidentKeyRequirement,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -51,9 +50,9 @@ pub trait DowngradableRequest<T> {
 
 #[cfg(test)]
 mod tests {
+    use crate::ops::webauthn::make_credential::ResidentKeyRequirement;
     use crate::ops::webauthn::{
-        DiscoverableCredentialRequirement, DowngradableRequest, MakeCredentialRequest,
-        UserVerificationRequirement,
+        DowngradableRequest, MakeCredentialRequest, UserVerificationRequirement,
     };
     use crate::proto::ctap2::{
         Ctap2COSEAlgorithmIdentifier, Ctap2CredentialType, Ctap2PublicKeyCredentialType,
@@ -63,7 +62,7 @@ mod tests {
     fn ctap2_make_credential_downgradable() {
         let mut request = MakeCredentialRequest::dummy();
         request.algorithms = vec![Ctap2CredentialType::default()];
-        request.discoverable_credential = Some(DiscoverableCredentialRequirement::Discouraged);
+        request.resident_key = Some(ResidentKeyRequirement::Discouraged);
         assert!(request.is_downgradable());
     }
 
@@ -71,7 +70,7 @@ mod tests {
     fn ctap2_make_credential_downgradable_unsupported_rk() {
         let mut request = MakeCredentialRequest::dummy();
         request.algorithms = vec![Ctap2CredentialType::default()];
-        request.discoverable_credential = Some(DiscoverableCredentialRequirement::Required);
+        request.resident_key = Some(ResidentKeyRequirement::Required);
         assert!(!request.is_downgradable());
     }
 

--- a/libwebauthn/src/ops/webauthn/make_credential.rs
+++ b/libwebauthn/src/ops/webauthn/make_credential.rs
@@ -98,9 +98,23 @@ impl MakeCredentialsResponseUnsignedExtensions {
                     // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#op-makecred-step-rk
                     // if the "rk" option is false: the authenticator MUST create a non-discoverable credential.
                     // Note: This step is a change from CTAP2.0 where if the "rk" option is false the authenticator could optionally create a discoverable credential.
-                    Some(CredentialPropsExtension {
-                        rk: Some(request.require_resident_key),
-                    })
+                    match request.discoverable_credential {
+                        Some(DiscoverableCredentialRequirement::Discouraged) | None => {
+                            Some(CredentialPropsExtension { rk: Some(false) })
+                        }
+                        Some(DiscoverableCredentialRequirement::Preferred) => {
+                            if info.map(|i| i.option_enabled("rk")).unwrap_or_default() {
+                                Some(CredentialPropsExtension { rk: Some(true) })
+                            } else {
+                                // Default value in case "rk" is missing (which it is in this constellation) is "false"
+                                // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#makecred-rk
+                                Some(CredentialPropsExtension { rk: Some(false) })
+                            }
+                        }
+                        Some(DiscoverableCredentialRequirement::Required) => {
+                            Some(CredentialPropsExtension { rk: Some(true) })
+                        }
+                    }
                 } else {
                     Some(CredentialPropsExtension {
                         // For CTAP 2.0, we can't say if "rk" is true or not.
@@ -135,6 +149,13 @@ impl MakeCredentialsResponseUnsignedExtensions {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum DiscoverableCredentialRequirement {
+    Required,
+    Preferred,
+    Discouraged,
+}
+
 #[derive(Debug, Clone)]
 pub struct MakeCredentialRequest {
     pub hash: Vec<u8>,
@@ -143,7 +164,7 @@ pub struct MakeCredentialRequest {
     pub relying_party: Ctap2PublicKeyCredentialRpEntity,
     /// userEntity
     pub user: Ctap2PublicKeyCredentialUserEntity,
-    pub require_resident_key: bool,
+    pub discoverable_credential: Option<DiscoverableCredentialRequirement>,
     pub user_verification: UserVerificationRequirement,
     /// credTypesAndPubKeyAlgs
     pub algorithms: Vec<Ctap2CredentialType>,
@@ -270,7 +291,7 @@ impl MakeCredentialRequest {
             exclude: None,
             extensions: None,
             origin: "example.org".to_owned(),
-            require_resident_key: false,
+            discoverable_credential: None,
             user_verification: UserVerificationRequirement::Discouraged,
             timeout: Duration::from_secs(10),
         }
@@ -294,7 +315,10 @@ impl DowngradableRequest<RegisterRequest> for MakeCredentialRequest {
         }
 
         // Options must not include "rk" set to true.
-        if self.require_resident_key {
+        if matches!(
+            self.discoverable_credential,
+            Some(DiscoverableCredentialRequirement::Required)
+        ) {
             debug!("Not downgradable: request requires resident key");
             return false;
         }

--- a/libwebauthn/src/proto/ctap2/model/make_credential.rs
+++ b/libwebauthn/src/proto/ctap2/model/make_credential.rs
@@ -7,8 +7,9 @@ use super::{
 use crate::{
     fido::AuthenticatorData,
     ops::webauthn::{
-        CredentialProtectionPolicy, MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension,
-        MakeCredentialRequest, MakeCredentialResponse, MakeCredentialsRequestExtensions,
+        CredentialProtectionPolicy, DiscoverableCredentialRequirement,
+        MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension, MakeCredentialRequest,
+        MakeCredentialResponse, MakeCredentialsRequestExtensions,
         MakeCredentialsResponseUnsignedExtensions,
     },
     pin::PinUvAuthProtocol,
@@ -19,6 +20,7 @@ use ctap_types::ctap2::credential_management::CredentialProtectionPolicy as Ctap
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use serde_indexed::{DeserializeIndexed, SerializeIndexed};
+use tracing::warn;
 
 #[derive(Debug, Default, Clone, Copy, Serialize)]
 pub struct Ctap2MakeCredentialOptions {
@@ -123,73 +125,54 @@ impl Ctap2MakeCredentialRequest {
         req: &MakeCredentialRequest,
         info: &Ctap2GetInfoResponse,
     ) -> Result<Self, Error> {
-        // Cloning it, so we can modify it
-        let mut req = req.clone();
         // Checking if extensions can be fulfilled
-        //
-        // CredProtection
-        // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#credProtectFeatureDetection
-        // When enforceCredentialProtectionPolicy is true, and credentialProtectionPolicy's value
-        // is either userVerificationOptionalWithCredentialIDList or userVerificationRequired,
-        // the platform SHOULD NOT create the credential in a way that does not implement the
-        // requested protection policy. (For example, by creating it on an authenticator that
-        // does not support this extension.)
-        if let Some(cred_protection) = req
-            .extensions
-            .as_ref()
-            .and_then(|x| x.cred_protect.as_ref())
-        {
-            if cred_protection.enforce_policy
-                && cred_protection.policy != CredentialProtectionPolicy::UserVerificationOptional
-                && !info.is_uv_protected()
-            {
-                return Err(Error::Ctap(CtapError::UnsupportedExtension));
+        let extensions = match &req.extensions {
+            Some(ext) => {
+                Some(Ctap2MakeCredentialsRequestExtensions::from_webauthn_request(ext, info)?)
             }
-        }
+            None => None,
+        };
 
-        // LargeBlob (NOTE: Not to be confused with LargeBlobKey. LargeBlob has "Preferred" as well)
-        // https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#largeblob
-        //
-        // "required": The credential will be created with an authenticator to store blobs. The create() call will fail if this is impossible.
-        if let Some(ext) = req.extensions.as_mut() {
-            if ext.large_blob == MakeCredentialLargeBlobExtension::Required
-                && !info.option_enabled("largeBlobs")
-            {
-                return Err(Error::Ctap(CtapError::UnsupportedExtension));
-            }
-            if !info.option_enabled("largeBlobs")
-                && ext.large_blob == MakeCredentialLargeBlobExtension::Preferred
-            {
-                // If it is preferred and the device does not support it, deactivate it.
-                // Then we can simply activate it later for all but None
-                ext.large_blob = MakeCredentialLargeBlobExtension::None;
-            }
-        }
-        Ok(Ctap2MakeCredentialRequest::from(req))
-    }
-}
-
-impl From<MakeCredentialRequest> for Ctap2MakeCredentialRequest {
-    fn from(op: MakeCredentialRequest) -> Ctap2MakeCredentialRequest {
-        Ctap2MakeCredentialRequest {
-            hash: ByteBuf::from(op.hash),
-            relying_party: op.relying_party,
-            user: op.user,
-            algorithms: op.algorithms,
-            exclude: op.exclude,
-            extensions: op.extensions.map(|x| x.into()),
-            options: Some(Ctap2MakeCredentialOptions {
-                require_resident_key: if op.require_resident_key {
+        // Discoverable credential / resident key requirements
+        let require_resident_key = match req.discoverable_credential {
+            Some(DiscoverableCredentialRequirement::Discouraged) => Some(false),
+            Some(DiscoverableCredentialRequirement::Preferred) => {
+                if info.option_enabled("rk") {
                     Some(true)
                 } else {
+                    // The device does not support rk, so we try to not even mention it in the
+                    // final request, to avoid the possibility of weird devices failing.
+                    // If they don't support it, the default will not be to create a discoverable
+                    // credential.
                     None
-                },
+                }
+            }
+            Some(DiscoverableCredentialRequirement::Required) => {
+                if !info.option_enabled("rk") {
+                    warn!("This request will potentially fail. Discoverable credential required, but device does not support it.");
+                }
+                // We still send the request to the device and let it sort it out.
+                // We only add a warning for easier debugging.
+                Some(true)
+            }
+            None => None,
+        };
+
+        Ok(Ctap2MakeCredentialRequest {
+            hash: ByteBuf::from(req.hash.clone()),
+            relying_party: req.relying_party.clone(),
+            user: req.user.clone(),
+            algorithms: req.algorithms.clone(),
+            exclude: req.exclude.clone(),
+            extensions,
+            options: Some(Ctap2MakeCredentialOptions {
+                require_resident_key,
                 deprecated_require_user_verification: None,
             }),
             pin_auth_param: None,
             pin_auth_proto: None,
             enterprise_attestation: None,
-        }
+        })
     }
 }
 
@@ -219,27 +202,70 @@ impl Ctap2MakeCredentialsRequestExtensions {
     }
 }
 
-impl From<MakeCredentialsRequestExtensions> for Ctap2MakeCredentialsRequestExtensions {
-    fn from(other: MakeCredentialsRequestExtensions) -> Self {
-        let hmac_secret = match other.hmac_or_prf {
+impl Ctap2MakeCredentialsRequestExtensions {
+    fn from_webauthn_request(
+        requested_extensions: &MakeCredentialsRequestExtensions,
+        info: &Ctap2GetInfoResponse,
+    ) -> Result<Self, Error> {
+        // CredProtection
+        // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#credProtectFeatureDetection
+        // When enforceCredentialProtectionPolicy is true, and credentialProtectionPolicy's value
+        // is either userVerificationOptionalWithCredentialIDList or userVerificationRequired,
+        // the platform SHOULD NOT create the credential in a way that does not implement the
+        // requested protection policy. (For example, by creating it on an authenticator that
+        // does not support this extension.)
+        if let Some(cred_protection) = requested_extensions.cred_protect.as_ref() {
+            if cred_protection.enforce_policy
+                && cred_protection.policy != CredentialProtectionPolicy::UserVerificationOptional
+                && !info.is_uv_protected()
+            {
+                return Err(Error::Ctap(CtapError::UnsupportedExtension));
+            }
+        }
+
+        // LargeBlob (NOTE: Not to be confused with LargeBlobKey. LargeBlob has "Preferred" as well)
+        // https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#largeblob
+        //
+        let large_blob_key = match requested_extensions.large_blob {
+            MakeCredentialLargeBlobExtension::Required => {
+                // "required": The credential will be created with an authenticator to store blobs. The create() call will fail if this is impossible.
+                if !info.option_enabled("largeBlobs") {
+                    warn!("This request will potentially fail. Large blob extension required, but device does not support it.");
+                }
+                // We still send the request to the device and let it sort it out.
+                // We only add a warning for easier debugging.
+                Some(true)
+            }
+            MakeCredentialLargeBlobExtension::Preferred => {
+                if info.option_enabled("largeBlobs") {
+                    Some(true)
+                } else {
+                    // The device does not support large blobs, so we try to not even mention it in the
+                    // final request, to avoid the possibility of weird devices failing.
+                    None
+                }
+            }
+            MakeCredentialLargeBlobExtension::None => None,
+        };
+
+        // HMAC Secret
+        let hmac_secret = match requested_extensions.hmac_or_prf {
             MakeCredentialHmacOrPrfInput::None => None,
             MakeCredentialHmacOrPrfInput::HmacGetSecret | MakeCredentialHmacOrPrfInput::Prf => {
                 Some(true)
             }
         };
-        Ctap2MakeCredentialsRequestExtensions {
-            cred_blob: other.cred_blob,
+
+        Ok(Ctap2MakeCredentialsRequestExtensions {
+            cred_blob: requested_extensions.cred_blob.clone(),
             hmac_secret,
-            cred_protect: other.cred_protect.map(|x| x.policy.into()),
-            large_blob_key: if other.large_blob == MakeCredentialLargeBlobExtension::None {
-                None
-            } else {
-                // We modified "Preferred" to "None" if the device does not support it,
-                // so we can be sure to request it here for all but "None"
-                Some(true)
-            },
-            min_pin_length: other.min_pin_length,
-        }
+            cred_protect: requested_extensions
+                .cred_protect
+                .as_ref()
+                .map(|x| x.policy.clone().into()),
+            large_blob_key,
+            min_pin_length: requested_extensions.min_pin_length,
+        })
     }
 }
 

--- a/libwebauthn/src/proto/ctap2/model/make_credential.rs
+++ b/libwebauthn/src/proto/ctap2/model/make_credential.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     fido::AuthenticatorData,
     ops::webauthn::{
-        CredentialProtectionPolicy, DiscoverableCredentialRequirement,
+        CredentialProtectionPolicy, ResidentKeyRequirement,
         MakeCredentialHmacOrPrfInput, MakeCredentialLargeBlobExtension, MakeCredentialRequest,
         MakeCredentialResponse, MakeCredentialsRequestExtensions,
         MakeCredentialsResponseUnsignedExtensions,
@@ -134,9 +134,9 @@ impl Ctap2MakeCredentialRequest {
         };
 
         // Discoverable credential / resident key requirements
-        let require_resident_key = match req.discoverable_credential {
-            Some(DiscoverableCredentialRequirement::Discouraged) => Some(false),
-            Some(DiscoverableCredentialRequirement::Preferred) => {
+        let require_resident_key = match req.resident_key {
+            Some(ResidentKeyRequirement::Discouraged) => Some(false),
+            Some(ResidentKeyRequirement::Preferred) => {
                 if info.option_enabled("rk") {
                     Some(true)
                 } else {
@@ -147,7 +147,7 @@ impl Ctap2MakeCredentialRequest {
                     None
                 }
             }
-            Some(DiscoverableCredentialRequirement::Required) => {
+            Some(ResidentKeyRequirement::Required) => {
                 if !info.option_enabled("rk") {
                     warn!("This request will potentially fail. Discoverable credential required, but device does not support it.");
                 }


### PR DESCRIPTION
Switched away from a context-less `From<MakeCredentialRequest> for Ctap2MakeCredentialRequest` implementation to a dedicated function that can additionally receive the device-info to make that transformation.
Now we also don't need to copy the original request and modify it (which was always a bit icky), but we can do the direct translation to the Ctap2-request.