### PR TITLE
extended the tests for AuthData deserialization

### DIFF
--- a/libwebauthn/src/proto/ctap2/cbor/mod.rs
+++ b/libwebauthn/src/proto/ctap2/cbor/mod.rs
@@ -4,4 +4,4 @@ mod serde;
 
 pub use request::CborRequest;
 pub use response::CborResponse;
-pub(crate) use serde::{from_reader, from_cursor, from_slice, to_vec, CborError, Value};
+pub(crate) use serde::{from_cursor, from_slice, to_vec, CborError, Value};

--- a/libwebauthn/src/proto/ctap2/cbor/serde.rs
+++ b/libwebauthn/src/proto/ctap2/cbor/serde.rs
@@ -26,14 +26,6 @@ where
     serde_cbor::ser::to_vec(serializable).map_err(CborError::from)
 }
 
-pub(crate) fn from_reader<T, R>(reader: R) -> Result<T, CborError>
-where
-    T: for<'de> serde::Deserialize<'de>,
-    R: std::io::Read,
-{
-    serde_cbor::de::from_reader(reader).map_err(CborError::from)
-}
-
 /// Decodes a value from CBOR data in a reader without checking that there is no trailing data
 pub(crate) fn from_cursor<T, R>(reader: R) -> Result<T, CborError>
 where


### PR DESCRIPTION
As suggested by @AlfioEmanueleFresta in #136 in https://github.com/linux-credentials/libwebauthn/pull/136#pullrequestreview-3059589590 added a test for deserializing AuthData.

To be able to test this, I had to pull out the AuthenticatorDataVisitor struct to make the visit_bytes function available, I understand that this exposes the implementation details a bit, so might not be the best solution here. I'm open for suggestions.