### PR TITLE
Switch virt device to RAM only and use message passing to allow for state to be kept across device lifetime

### DIFF
--- a/libwebauthn/Cargo.lock
+++ b/libwebauthn/Cargo.lock
@@ -63,10 +63,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "apdu-app"
@@ -499,6 +543,12 @@ checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -972,6 +1022,27 @@ dependencies = [
  "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -1454,6 +1525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "iso7816"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +1681,7 @@ dependencies = [
  "ctaphid-dispatch",
  "curve25519-dalek",
  "dbus",
+ "delog",
  "fido-authenticator",
  "futures",
  "heapless",
@@ -1631,6 +1709,7 @@ dependencies = [
  "sha2 0.10.9",
  "snow",
  "tempfile",
+ "test-log",
  "text_io",
  "thiserror 2.0.16",
  "time",
@@ -1955,6 +2034,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opaque-debug"
@@ -2907,6 +2992,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "test-log"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "text_io"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3314,6 +3421,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -77,12 +77,16 @@ qrcode = "0.14.1"
 # on fido-authenticator.
 ctaphid-dispatch = { version = "0.3" }
 ctaphid = { version = "0.3.1", default-features = false }
-fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git",tag = "v0.1.1-nitrokey.27", features = ["dispatch"] }
+fido-authenticator = { git = "https://github.com/Nitrokey/fido-authenticator.git",tag = "v0.1.1-nitrokey.27", features = ["dispatch", "log-all"] }
 littlefs2 = { version = "0.6.0" }
 trussed = { version = "0.1", features = ["virt"] }
 trussed-staging = { version = "0.3.0", features = ["chunked", "hkdf", "virt", "fs-info"] }
 interchange = { version = "0.3.0" }
 tempfile = { version = "3.21" }
+# For turning on logging in fido-authenticator
+delog = { version = "0.1", features = ["std-log"]}
+# For turning on logging in unittests
+test-log = { version = "0.2" }
 
 # The trussed ecosystem is currently a bit messy, so we have to do some patching of the versions
 [patch.crates-io]

--- a/libwebauthn/src/proto/ctap2/preflight.rs
+++ b/libwebauthn/src/proto/ctap2/preflight.rs
@@ -71,3 +71,308 @@ pub(crate) async fn ctap2_preflight<C: Channel>(
     info!("Credential list AFTER preflight: {filtered_list:?}");
     filtered_list
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use rand::{thread_rng, Rng};
+    use serde_bytes::ByteBuf;
+    use test_log::test;
+    use tokio::sync::broadcast::Receiver;
+
+    async fn expected_uv_updates(
+        mut state_recv: Receiver<UvUpdate>,
+        expected_updates: &[UvUpdate],
+    ) {
+        for expected_update in expected_updates {
+            let update = state_recv
+                .recv()
+                .await
+                .expect("Failed to receive UV update");
+            assert_eq!(expected_update, &update);
+        }
+    }
+
+    use crate::{
+        ops::webauthn::{
+            GetAssertionRequest, GetAssertionResponse, MakeCredentialRequest,
+            ResidentKeyRequirement, UserVerificationRequirement,
+        },
+        proto::{
+            ctap2::{
+                Ctap2CredentialType, Ctap2PublicKeyCredentialDescriptor,
+                Ctap2PublicKeyCredentialRpEntity, Ctap2PublicKeyCredentialType,
+                Ctap2PublicKeyCredentialUserEntity,
+            },
+            CtapError,
+        },
+        transport::{
+            hid::{channel::HidChannel, get_virtual_device},
+            Channel, Device,
+        },
+        webauthn::{Error, WebAuthn},
+        UvUpdate,
+    };
+
+    use super::ctap2_preflight;
+
+    const TIMEOUT: Duration = Duration::from_secs(10);
+
+    async fn make_credential_call(
+        channel: &mut HidChannel<'_>,
+        user_id: &[u8],
+        exclude_list: Option<Vec<Ctap2PublicKeyCredentialDescriptor>>,
+    ) -> Result<(Ctap2PublicKeyCredentialDescriptor, [u8; 32]), Error> {
+        let challenge: [u8; 32] = thread_rng().gen();
+        let make_credentials_request = MakeCredentialRequest {
+            origin: "example.org".to_owned(),
+            hash: Vec::from(challenge),
+            relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
+            user: Ctap2PublicKeyCredentialUserEntity::new(user_id, "mario.rossi", "Mario Rossi"),
+            resident_key: Some(ResidentKeyRequirement::Discouraged),
+            user_verification: UserVerificationRequirement::Preferred,
+            algorithms: vec![Ctap2CredentialType::default()],
+            exclude: exclude_list,
+            extensions: None,
+            timeout: TIMEOUT,
+        };
+
+        let response = channel
+            .webauthn_make_credential(&make_credentials_request)
+            .await;
+        response.map(|x| ((&x.authenticator_data).try_into().unwrap(), challenge))
+    }
+
+    async fn get_assertion_call(
+        channel: &mut HidChannel<'_>,
+        allow_list: Vec<Ctap2PublicKeyCredentialDescriptor>,
+    ) -> Result<GetAssertionResponse, Error> {
+        let challenge: [u8; 32] = thread_rng().gen();
+        let get_assertion = GetAssertionRequest {
+            relying_party_id: "example.org".to_owned(),
+            hash: Vec::from(challenge),
+            allow: allow_list,
+            user_verification: UserVerificationRequirement::Discouraged,
+            extensions: None,
+            timeout: TIMEOUT,
+        };
+
+        channel.webauthn_get_assertion(&get_assertion).await
+    }
+
+    fn create_credential(id: &[u8]) -> Ctap2PublicKeyCredentialDescriptor {
+        Ctap2PublicKeyCredentialDescriptor {
+            r#type: Ctap2PublicKeyCredentialType::PublicKey,
+            id: ByteBuf::from(id),
+            transports: None,
+        }
+    }
+
+    #[test(tokio::test)]
+    async fn preflight_no_exclude_list() {
+        // Make credential with exclude_list: None. Should do nothing in preflight and return a credential
+        let mut device = get_virtual_device();
+        let mut channel = device.channel().await.unwrap();
+
+        let user_id: [u8; 32] = thread_rng().gen();
+
+        let state_recv = channel.get_ux_update_receiver();
+        let hash: [u8; 32] = thread_rng().gen();
+        let filtered_list = ctap2_preflight(&mut channel, &[], &hash, "example.org").await;
+        assert!(filtered_list.is_empty());
+
+        let res = make_credential_call(&mut channel, &user_id, None).await;
+
+        expected_uv_updates(state_recv, &[UvUpdate::PresenceRequired]).await;
+
+        assert!(res.is_ok());
+    }
+
+    #[test(tokio::test)]
+    async fn preflight_nonsense_exclude_list() {
+        // Make credential with nonsense exclude_list. Should remove everything in preflight and return a credential
+
+        let mut device = get_virtual_device();
+        let mut channel = device.channel().await.unwrap();
+
+        let user_id: [u8; 32] = thread_rng().gen();
+
+        let state_recv = channel.get_ux_update_receiver();
+
+        let exclude_list = vec![
+            create_credential(&[9, 8, 7, 6, 5, 4, 3, 2, 1]),
+            create_credential(&[8, 7, 6, 5, 4, 3, 2, 1, 9]),
+            create_credential(&[7, 6, 5, 4, 3, 2, 1, 9, 8]),
+        ];
+
+        let hash: [u8; 32] = thread_rng().gen();
+        let filtered_list =
+            ctap2_preflight(&mut channel, &exclude_list, &hash, "example.org").await;
+        assert!(filtered_list.is_empty());
+
+        let res = make_credential_call(&mut channel, &user_id, Some(exclude_list)).await;
+
+        expected_uv_updates(state_recv, &[UvUpdate::PresenceRequired]).await;
+
+        assert!(res.is_ok());
+    }
+
+    #[test(tokio::test)]
+    async fn preflight_mixed_exclude_list() {
+        // Make credential with a mixed exclude_list that contains 2 real ones. Should remove the two fake ones in preflight and return an error
+
+        let mut device = get_virtual_device();
+        let mut channel = device.channel().await.unwrap();
+
+        let user_id: [u8; 32] = thread_rng().gen();
+
+        let state_recv = channel.get_ux_update_receiver();
+
+        let res = make_credential_call(&mut channel, &user_id, None).await;
+        let (first_credential, _) = res.expect("Failed to register first credential");
+
+        let res = make_credential_call(&mut channel, &user_id, None).await;
+        let (second_credential, hash) = res.expect("Failed to register second credential");
+
+        let exclude_list = vec![
+            create_credential(&[9, 8, 7, 6, 5, 4, 3, 2, 1]),
+            first_credential.clone(),
+            create_credential(&[8, 7, 6, 5, 4, 3, 2, 1, 9]),
+            second_credential.clone(),
+            create_credential(&[7, 6, 5, 4, 3, 2, 1, 9, 8]),
+        ];
+
+        let filtered_list =
+            ctap2_preflight(&mut channel, &exclude_list, &hash, "example.org").await;
+        assert_eq!(filtered_list.len(), 2);
+        assert_eq!(filtered_list[0].id, first_credential.id);
+        assert_eq!(filtered_list[1].id, second_credential.id);
+
+        let res = make_credential_call(&mut channel, &user_id, Some(exclude_list)).await;
+        assert!(matches!(
+            res,
+            Err(Error::Ctap(CtapError::CredentialExcluded))
+        ));
+
+        expected_uv_updates(
+            state_recv,
+            &[
+                UvUpdate::PresenceRequired,
+                UvUpdate::PresenceRequired,
+                UvUpdate::PresenceRequired,
+            ],
+        )
+        .await;
+    }
+
+    #[test(tokio::test)]
+    async fn preflight_no_allow_list() {
+        // Get assertion with allow_list: None. Should do nothing in preflight and return an error OR credentials, if a discoverable credential for example.org is present on the device
+
+        let mut device = get_virtual_device();
+        let mut channel = device.channel().await.unwrap();
+
+        let user_id: [u8; 32] = thread_rng().gen();
+
+        let state_recv = channel.get_ux_update_receiver();
+        let res = make_credential_call(&mut channel, &user_id, None).await;
+        let (_credential, hash) = res.expect("Failed to register first credential");
+
+        let filtered_list = ctap2_preflight(&mut channel, &[], &hash, "example.org").await;
+        assert!(filtered_list.is_empty());
+
+        let allow_list = Vec::new();
+        let res = get_assertion_call(&mut channel, allow_list).await;
+        assert!(matches!(res, Err(Error::Ctap(CtapError::NoCredentials))));
+
+        expected_uv_updates(
+            state_recv,
+            &[UvUpdate::PresenceRequired, UvUpdate::PresenceRequired],
+        )
+        .await;
+    }
+
+    #[test(tokio::test)]
+    async fn preflight_nonsense_allow_list() {
+        // Get assertion with nonsense allow_list. Should remove everything in preflight and return an error, AND run a dummy request to provoke a touch
+
+        let mut device = get_virtual_device();
+        let mut channel = device.channel().await.unwrap();
+
+        let user_id: [u8; 32] = thread_rng().gen();
+
+        let state_recv = channel.get_ux_update_receiver();
+        let res = make_credential_call(&mut channel, &user_id, None).await;
+        let (_credential, hash) = res.expect("Failed to register first credential");
+
+        let allow_list = vec![
+            create_credential(&[9, 8, 7, 6, 5, 4, 3, 2, 1]),
+            create_credential(&[8, 7, 6, 5, 4, 3, 2, 1, 9]),
+            create_credential(&[7, 6, 5, 4, 3, 2, 1, 9, 8]),
+        ];
+
+        let filtered_list = ctap2_preflight(&mut channel, &allow_list, &hash, "example.org").await;
+        assert!(filtered_list.is_empty());
+
+        let res = get_assertion_call(&mut channel, allow_list).await;
+        assert!(matches!(res, Err(Error::Ctap(CtapError::NoCredentials))));
+
+        expected_uv_updates(
+            state_recv,
+            &[UvUpdate::PresenceRequired, UvUpdate::PresenceRequired],
+        )
+        .await;
+    }
+
+    #[test(tokio::test)]
+    async fn preflight_mixed_allow_list() {
+        // Get assertion with a mixed allow_list that contains 2 real ones. Should remove the two fake ones in preflight
+
+        let mut device = get_virtual_device();
+        let mut channel = device.channel().await.unwrap();
+
+        let user_id: [u8; 32] = thread_rng().gen();
+
+        let state_recv = channel.get_ux_update_receiver();
+        let (first_credential, _) = make_credential_call(&mut channel, &user_id, None)
+            .await
+            .expect("Failed to register first credential");
+        let (second_credential, hash) = make_credential_call(&mut channel, &user_id, None)
+            .await
+            .expect("Failed to register second credential");
+
+        let allow_list = vec![
+            create_credential(&[9, 8, 7, 6, 5, 4, 3, 2, 1]),
+            first_credential.clone(),
+            create_credential(&[8, 7, 6, 5, 4, 3, 2, 1, 9]),
+            second_credential.clone(),
+        ];
+
+        let filtered_list = ctap2_preflight(&mut channel, &allow_list, &hash, "example.org").await;
+        assert_eq!(filtered_list.len(), 2);
+        assert_eq!(filtered_list[0].id, first_credential.id);
+        assert_eq!(filtered_list[1].id, second_credential.id);
+
+        let res = get_assertion_call(&mut channel, allow_list)
+            .await
+            .expect("getAssertion call failed");
+        // We have non-discoverable credentials here, so the authenticator
+        // will return on the first one in the allow_list it finds
+        assert_eq!(res.assertions.len(), 1);
+        assert_eq!(
+            res.assertions[0]
+                .credential_id
+                .as_ref()
+                .expect("Assertion 0 has no credential ID")
+                .id,
+            filtered_list[0].id
+        );
+
+        expected_uv_updates(
+            state_recv,
+            &[UvUpdate::PresenceRequired, UvUpdate::PresenceRequired],
+        )
+        .await;
+    }
+}

--- a/libwebauthn/src/tests/basic_ctap2.rs
+++ b/libwebauthn/src/tests/basic_ctap2.rs
@@ -13,6 +13,7 @@ use crate::{
     },
 };
 use rand::{thread_rng, Rng};
+use test_log::test;
 use tokio::sync::broadcast::Receiver;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -24,7 +25,7 @@ async fn handle_updates(mut state_recv: Receiver<UvUpdate>) {
     assert_eq!(state_recv.recv().await, Ok(UvUpdate::PresenceRequired));
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_webauthn_basic_ctap2() {
     let mut device = get_virtual_device();
 

--- a/libwebauthn/src/tests/mod.rs
+++ b/libwebauthn/src/tests/mod.rs
@@ -1,4 +1,3 @@
 pub mod basic_ctap1;
 pub mod basic_ctap2;
-pub mod channel;
 pub mod prf;

--- a/libwebauthn/src/tests/mod.rs
+++ b/libwebauthn/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub mod basic_ctap1;
 pub mod basic_ctap2;
 pub mod channel;
+pub mod prf;

--- a/libwebauthn/src/transport/mock/channel.rs
+++ b/libwebauthn/src/transport/mock/channel.rs
@@ -14,14 +14,14 @@ use crate::{
     UvUpdate,
 };
 
-pub struct TestChannel {
+pub struct MockChannel {
     expected_requests: VecDeque<CborRequest>,
     responses: VecDeque<CborResponse>,
     auth_token_data: Option<AuthTokenData>,
     ux_update_sender: broadcast::Sender<UvUpdate>,
 }
 
-impl TestChannel {
+impl MockChannel {
     pub fn new() -> Self {
         let (ux_update_sender, _) = broadcast::channel(16);
         Self {
@@ -38,7 +38,7 @@ impl TestChannel {
     }
 }
 
-impl Ctap2AuthTokenStore for TestChannel {
+impl Ctap2AuthTokenStore for MockChannel {
     fn store_auth_data(&mut self, auth_token_data: AuthTokenData) {
         self.auth_token_data = Some(auth_token_data);
     }
@@ -52,14 +52,14 @@ impl Ctap2AuthTokenStore for TestChannel {
     }
 }
 
-impl Display for TestChannel {
+impl Display for MockChannel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "TestChannel")
     }
 }
 
 #[async_trait]
-impl Channel for TestChannel {
+impl Channel for MockChannel {
     type UxUpdate = UvUpdate;
 
     fn get_ux_update_sender(&self) -> &broadcast::Sender<Self::UxUpdate> {

--- a/libwebauthn/src/transport/mock/mod.rs
+++ b/libwebauthn/src/transport/mock/mod.rs
@@ -1,0 +1,1 @@
+pub mod channel;

--- a/libwebauthn/src/transport/mod.rs
+++ b/libwebauthn/src/transport/mod.rs
@@ -5,6 +5,12 @@ pub mod cable;
 pub mod device;
 pub mod hid;
 #[cfg(test)]
+/// A mock channel that can be used in tests to
+/// queue expected requests and responses in unittests
+pub mod mock;
+#[cfg(test)]
+/// Fully fledged virtual device based on trussed
+/// for end2end tests
 pub mod virt;
 
 mod channel;

--- a/libwebauthn/src/transport/virt/mod.rs
+++ b/libwebauthn/src/transport/virt/mod.rs
@@ -5,89 +5,123 @@ use super::hid::framing::HidCommand;
 use super::hid::framing::HidMessage;
 use crate::webauthn::Error;
 use num_enum::TryFromPrimitive;
-use std::sync::Arc;
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread;
+use std::thread::JoinHandle;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct VirtHidDevice {
-    storage_dir: Arc<tempfile::TempDir>,
-    response: Option<HidMessage>,
+    req_tx: Sender<HidMessage>,
+    resp_rx: Receiver<HidMessage>,
+    _device_thread: JoinHandle<()>,
+}
+
+impl Drop for VirtHidDevice {
+    fn drop(&mut self) {
+        // Telling the thread to quit
+        let _ = self
+            .req_tx
+            .send(HidMessage::new(0, HidCommand::Cancel, &[]));
+    }
 }
 
 impl VirtHidDevice {
     pub fn new() -> Self {
-        let storage_dir =
-            tempfile::tempdir().expect("Failed to create temp. dir for virtual device storage");
+        let (req_tx, req_rx) = std::sync::mpsc::channel::<HidMessage>();
+        let (resp_tx, resp_rx) = std::sync::mpsc::channel::<HidMessage>();
+
+        // Due to the callback-structure of trussed, we simply can't call
+        // device::run_ctaphid() multiple times, as that would mean a new
+        // device initialization for each call (and rendering every shared
+        // secret invalid).
+        // So we let it run only once, but in a seperate thread, and simply
+        // pass messages back and forth.
+        // This way, the device works across multiple request calls,
+        // as long as the device-object lives. Everything is wiped on dropping
+        // the device object.
+        let thread_handle = thread::spawn(move || {
+            device::run_ctaphid(move |device| {
+                while let Ok(msg) = req_rx.recv() {
+                    let resp = match msg.cmd {
+                        HidCommand::Ping => device.ping(&msg.payload).map(|_| Vec::new()),
+                        HidCommand::Msg => device.ctap1(&msg.payload),
+                        // HidCommand::Lock => device.lock(duration),
+                        HidCommand::Init => {
+                            let mut payload = msg.payload.clone();
+                            // Fake channel ID
+                            payload.extend_from_slice(&[1, 2, 3, 4]);
+                            payload.push(device.protocol_version());
+                            let versions = device.device_version();
+                            payload.push(versions.major);
+                            payload.push(versions.minor);
+                            payload.push(versions.build);
+                            payload.push(device.capabilities().bits());
+                            Ok(payload)
+                        }
+                        HidCommand::Wink => device.wink().map(|_| Vec::new()),
+                        HidCommand::Cbor => {
+                            device
+                                .ctap2(msg.payload[0], &msg.payload[1..])
+                                .map(|payload| {
+                                    // For CBOR, we have to put the status code in front.
+                                    // If we get here, it was successful, so we add:
+                                    let mut status_with_payload = vec![0]; // Status code: Ok
+                                    status_with_payload.extend_from_slice(&payload);
+                                    status_with_payload
+                                })
+                        }
+                        HidCommand::Cancel => break,
+                        HidCommand::Lock
+                        | HidCommand::Sync
+                        | HidCommand::KeepAlive
+                        | HidCommand::Error => unimplemented!(),
+                    };
+                    match resp {
+                        Ok(payload) => {
+                            let mut response = msg.clone();
+                            response.payload = payload;
+                            match resp_tx.send(response) {
+                                Ok(_) => continue,
+                                Err(_) => break,
+                            }
+                        }
+                        Err(ctaphid::error::Error::CommandError(
+                            ctaphid::error::CommandError::CborError(value),
+                        )) => match crate::proto::CtapError::try_from_primitive(value) {
+                            Ok(_) => {
+                                // If we have a known Error status code, we return `Ok(())`
+                                // (because the transmission was successful, but the operation was not)
+                                // and let the code above us handle the error accordingly
+                                // on a subsequent recv-call
+                                let mut response = msg.clone();
+                                let status_with_payload = vec![value]; // Status code: Err
+                                response.payload = status_with_payload; // No additional payload
+                                match resp_tx.send(response) {
+                                    Ok(_) => continue,
+                                    Err(_) => break,
+                                }
+                            }
+                            Err(_) => panic!("Failed to parse CtapError from {value}"),
+                        },
+                        Err(err) => panic!("failed to execute CTAP2 command: {err:?}"),
+                    }
+                }
+            })
+        });
         Self {
-            response: None,
-            storage_dir: Arc::new(storage_dir),
+            _device_thread: thread_handle,
+            req_tx,
+            resp_rx,
         }
     }
 
     pub fn virt_send(&mut self, msg: &HidMessage) -> Result<(), Error> {
-        let mut response = msg.clone();
-        match device::run_ctaphid(self.storage_dir.path(), |device| {
-            match msg.cmd {
-                HidCommand::Ping => device.ping(&msg.payload).map(|_| Vec::new()),
-                HidCommand::Msg => device.ctap1(&msg.payload),
-                // HidCommand::Lock => device.lock(duration),
-                HidCommand::Init => {
-                    let mut payload = msg.payload.clone();
-                    // Fake channel ID
-                    payload.extend_from_slice(&[1, 2, 3, 4]);
-                    payload.push(device.protocol_version());
-                    let versions = device.device_version();
-                    payload.push(versions.major);
-                    payload.push(versions.minor);
-                    payload.push(versions.build);
-                    payload.push(device.capabilities().bits());
-                    Ok(payload)
-                }
-                HidCommand::Wink => device.wink().map(|_| Vec::new()),
-                HidCommand::Cbor => {
-                    device
-                        .ctap2(msg.payload[0], &msg.payload[1..])
-                        .map(|payload| {
-                            // For CBOR, we have to put the status code in front.
-                            // If we get here, it was successful, so we add:
-                            let mut status_with_payload = vec![0]; // Status code: Ok
-                            status_with_payload.extend_from_slice(&payload);
-                            status_with_payload
-                        })
-                }
-                HidCommand::Cancel
-                | HidCommand::Lock
-                | HidCommand::Sync
-                | HidCommand::KeepAlive
-                | HidCommand::Error => unimplemented!(),
-            }
-        }) {
-            Ok(payload) => {
-                assert!(self.response.is_none());
-                response.payload = payload;
-                self.response = Some(response);
-                Ok(())
-            }
-            Err(ctaphid::error::Error::CommandError(ctaphid::error::CommandError::CborError(
-                value,
-            ))) => match crate::proto::CtapError::try_from_primitive(value) {
-                Ok(_) => {
-                    // If we have a known Error status code, we return `Ok(())`
-                    // (because the transmission was successful, but the operation was not)
-                    // and let the code above us handle the error accordingly
-                    // on a subsequent recv-call
-                    let status_with_payload = vec![value]; // Status code: Err
-                    response.payload = status_with_payload; // No additional payload
-                    self.response = Some(response);
-                    Ok(())
-                }
-                Err(_) => panic!("Failed to parse CtapError from {value}"),
-            },
-            Err(err) => panic!("failed to execute CTAP2 command: {err:?}"),
-        }
+        let _ = self.req_tx.send(msg.to_owned());
+        Ok(())
     }
 
     pub fn virt_recv(&mut self) -> Result<HidMessage, Error> {
-        assert!(self.response.is_some());
-        Ok(self.response.take().unwrap())
+        let response = self.resp_rx.recv().unwrap();
+        Ok(response)
     }
 }

--- a/libwebauthn/src/webauthn/pin_uv_auth_token.rs
+++ b/libwebauthn/src/webauthn/pin_uv_auth_token.rs
@@ -431,7 +431,7 @@ mod test {
             },
             CtapError,
         },
-        tests::channel::TestChannel,
+        transport::mock::channel::MockChannel,
         transport::{Channel, Ctap2AuthTokenStore},
         webauthn::UsedPinUvAuthToken,
         UvUpdate,
@@ -485,7 +485,7 @@ mod test {
         extensions: Option<GetAssertionRequestExtensions>,
         expected_result: Result<UsedPinUvAuthToken, Error>,
     ) {
-        let mut channel = TestChannel::new();
+        let mut channel = MockChannel::new();
         let info = create_info(info_options, info_extensions);
         let info_req = CborRequest::new(Ctap2CommandCode::AuthenticatorGetInfo);
         let info_resp = CborResponse::new_success_from_slice(to_vec(&info).unwrap().as_slice());
@@ -712,7 +712,7 @@ mod test {
                 ..Default::default()
             });
 
-            let mut channel = TestChannel::new();
+            let mut channel = MockChannel::new();
             let mut info = create_info(&info_options, Some(&["hmac-secret"]));
             info.pin_auth_protos = Some(vec![1]);
             let info_req = CborRequest::new(Ctap2CommandCode::AuthenticatorGetInfo);
@@ -774,7 +774,7 @@ mod test {
                 ..Default::default()
             });
 
-            let mut channel = TestChannel::new();
+            let mut channel = MockChannel::new();
 
             // Queueing GetInfo request and response
             let mut info = create_info(&info_options, Some(&["hmac-secret"]));
@@ -882,7 +882,7 @@ mod test {
                 ..Default::default()
             });
 
-            let mut channel = TestChannel::new();
+            let mut channel = MockChannel::new();
 
             // Queueing GetInfo request and response
             let mut info = create_info(&info_options, Some(&["hmac-secret"]));

--- a/libwebauthn/src/webauthn/pin_uv_auth_token.rs
+++ b/libwebauthn/src/webauthn/pin_uv_auth_token.rs
@@ -22,7 +22,7 @@ use crate::{PinRequiredUpdate, UvUpdate};
 
 pub(crate) enum UsedPinUvAuthToken {
     FromStorage,
-    NewlyCalculated,
+    NewlyCalculated(Ctap2UserVerificationOperation),
     LegacyUV,
     SharedSecretOnly,
     None,
@@ -336,7 +336,7 @@ where
                 // Sets the pinUvAuthProtocol parameter to the value as selected when it obtained the shared secret.
                 ctap2_request.calculate_and_set_uv_auth(&uv_proto, uv_auth_token.as_slice());
 
-                Ok(UsedPinUvAuthToken::NewlyCalculated)
+                Ok(UsedPinUvAuthToken::NewlyCalculated(uv_operation))
             }
         }
     }
@@ -427,12 +427,11 @@ mod test {
                 cbor::{to_vec, CborRequest, CborResponse},
                 Ctap2ClientPinRequest, Ctap2ClientPinResponse, Ctap2CommandCode,
                 Ctap2GetAssertionRequest, Ctap2GetInfoResponse, Ctap2PinUvAuthProtocol,
-                Ctap2UserVerifiableRequest,
+                Ctap2UserVerifiableRequest, Ctap2UserVerificationOperation,
             },
             CtapError,
         },
-        transport::mock::channel::MockChannel,
-        transport::{Channel, Ctap2AuthTokenStore},
+        transport::{mock::channel::MockChannel, Channel, Ctap2AuthTokenStore},
         webauthn::UsedPinUvAuthToken,
         UvUpdate,
     };
@@ -763,7 +762,9 @@ mod test {
             ),
         ];
 
-        let expected_result = Ok(UsedPinUvAuthToken::NewlyCalculated);
+        let expected_result = Ok(UsedPinUvAuthToken::NewlyCalculated(
+            Ctap2UserVerificationOperation::GetPinUvAuthTokenUsingUvWithPermissions,
+        ));
 
         for (info_options, uv_requirement) in testcases {
             let extensions = Some(GetAssertionRequestExtensions {
@@ -871,7 +872,9 @@ mod test {
             ),
         ];
 
-        let expected_result = Ok(UsedPinUvAuthToken::NewlyCalculated);
+        let expected_result = Ok(UsedPinUvAuthToken::NewlyCalculated(
+            Ctap2UserVerificationOperation::GetPinUvAuthTokenUsingPinWithPermissions,
+        ));
 
         for (info_options, uv_requirement) in testcases {
             let extensions = Some(GetAssertionRequestExtensions {


### PR DESCRIPTION
Note: Needs rebasing after #149 lands, as this built on top of it.

### Commit 1:
Since the callback structure of nitrokeys/trusseds firmware makes it hard to have a 'normal' device, that can handle more than one consecutive requests without losing state, and after banging my head against this for quite some time, I opted for a rather blunt, but hopefully effective (enough) solution: Simple message passing. 

Now the callback-function is started in its own thread and requests+responses are passed back and forth via normal channels. 
I also removed the filesystem storage and went back to RAM storage only. This way, it should be possible to have multiple devices in parallel without any interference. As long as the device object lives, state is kept and things like "establishing shared secret, getting pinUvAuthToken, then doing the request" work, as the device is not reset between each request.

I added a rudimentary test-battery for PRF, demonstrating that this can now be done.

I also added a few more dev-dependencies to allow for better usage/debugging of this virtual device. With these, it is possible to show logging from the virtual fido-authenticator in the end2end-tests.

### Commit 2:
Renaming `TestChannel` to `MockChannel` (which I think explains better what it is) and moving the file out of `src/tests/`. I realized this would be very confusing, as in there are only tests that use the virtual device and not the `MockChannel`.
So now we have two testing transports under `src/transports/`, namely `virt` and `mock`, which hopefully is a bit more self-explanatory. 