### PR TITLE
Log when CTAP2 bio_enrollment responses return None fields

### DIFF
--- a/libwebauthn/src/management/bio_enrollment.rs
+++ b/libwebauthn/src/management/bio_enrollment.rs
@@ -20,7 +20,7 @@ use crate::{
 use async_trait::async_trait;
 use serde_bytes::ByteBuf;
 use std::time::Duration;
-use tracing::info;
+use tracing::{info, warn};
 
 #[async_trait]
 pub trait BioEnrollment {
@@ -84,7 +84,7 @@ where
         match resp.modality {
             Some(modality) => Ok(modality),
             None => {
-                info!("Channel did not return modality.");
+                warn!("Channel did not return modality.");
                 Err(Error::Ctap(CtapError::Other))
             }
         }
@@ -98,7 +98,7 @@ where
         // No UV needed
         let resp = self.ctap2_bio_enrollment(&req, timeout).await?;
         let Some(fingerprint_kind) = resp.fingerprint_kind else {
-            info!("Channel did not return fingerprint_kind in sensor info.");
+            warn!("Channel did not return fingerprint_kind in sensor info.");
             return Err(Error::Ctap(CtapError::Other))
         };
         Ok(Ctap2BioEnrollmentFingerprintSensorInfo {


### PR DESCRIPTION
This PR adds `info!` logs in the error paths for a couple of `BioEnrollment` implementation methods, which previously returned `Error::Ctap(CtapError::Other)` silently under some CTAP requests to channels, where the response had `None` fields that were expected to be `Some`.

Maintainers: Are these logs desirable in the context of #14 ? How appropriate are the messages and log-levels I have chosen?