### PR TITLE
Dynamically link hidraw library

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update apt cache
         run: sudo apt-get update
       - name: Install system dependencies
-        run: sudo apt-get install libudev-dev libdbus-1-dev libsodium-dev
+        run: sudo apt-get install libhidapi-dev libudev-dev libdbus-1-dev libsodium-dev
       - name: Build
         run: cargo build
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ $ cargo run --example webauthn_cable
 $ cargo run --example u2f_hid
 ```
 
+## Package Requirements
+
+- libhidapi-dev/hidapi-devel
+
 ## Contributing
 
 We welcome contributions!

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -49,7 +49,7 @@ curve25519-dalek = "4.1.3"
 hex = "0.4.3"
 mockall = "0.13.1"
 hidapi = { version = "2.4.1", default-features = false, features = [
-    "linux-static-hidraw",
+    "linux-shared-hidraw",
 ] }
 bitflags = "2.4.1"
 rand = "0.8.5"


### PR DESCRIPTION
This is up for discussion, but after removing some other dependencies, I noticed that the compilation time of hidapi increased (12.5 out of 56.3 seconds on my machine)

<img width="2656" height="1044" alt="image" src="https://github.com/user-attachments/assets/f8abc88e-02bf-48a5-9053-1ab9d98f0360" />

hidraw is ubiquitous on the OSes versions we target, so I don't think there's any harm in linking to the system library. (There is a [note in the docs from over 4 years ago](https://github.com/ruabmbua/hidapi-rs/commit/bbb7f3eb4ef91f71cbe2b39b4960019aa110112e#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R50-R51) that "hidraw might be buggy in older kernel versions", but I don't think that applies today.)