### PR TITLE
feat(ble): support FIDO2 for BLE transport, chooses best protocol available (fix #27)

### DIFF
--- a/libwebauthn/src/transport/ble/btleplug/manager.rs
+++ b/libwebauthn/src/transport/ble/btleplug/manager.rs
@@ -49,6 +49,11 @@ impl SupportedRevisions {
             }
         }
     }
+
+    pub fn select_best(&self) -> Option<FidoRevision> {
+        self.select_protocol(FidoProtocol::FIDO2)
+            .or_else(|| self.select_protocol(FidoProtocol::U2F))
+    }
 }
 
 async fn on_peripheral_service_data(
@@ -240,4 +245,60 @@ async fn discover_services(peripheral: &Peripheral) -> Result<FidoEndpoints, Err
         status,
         service_revision_bitfield,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fido::FidoRevision;
+
+    #[test]
+    fn select_best_prefers_fido2() {
+        let revisions = SupportedRevisions {
+            u2fv11: true,
+            u2fv12: true,
+            v2: true,
+        };
+        assert_eq!(revisions.select_best(), Some(FidoRevision::V2));
+    }
+
+    #[test]
+    fn select_best_falls_back_to_u2f() {
+        let revisions = SupportedRevisions {
+            u2fv11: true,
+            u2fv12: true,
+            v2: false,
+        };
+        assert_eq!(revisions.select_best(), Some(FidoRevision::U2fv12));
+    }
+
+    #[test]
+    fn select_best_falls_back_to_u2fv11() {
+        let revisions = SupportedRevisions {
+            u2fv11: true,
+            u2fv12: false,
+            v2: false,
+        };
+        assert_eq!(revisions.select_best(), Some(FidoRevision::U2fv11));
+    }
+
+    #[test]
+    fn select_best_fido2_only() {
+        let revisions = SupportedRevisions {
+            u2fv11: false,
+            u2fv12: false,
+            v2: true,
+        };
+        assert_eq!(revisions.select_best(), Some(FidoRevision::V2));
+    }
+
+    #[test]
+    fn select_best_none_supported() {
+        let revisions = SupportedRevisions {
+            u2fv11: false,
+            u2fv12: false,
+            v2: false,
+        };
+        assert_eq!(revisions.select_best(), None);
+    }
 }

--- a/libwebauthn/src/transport/ble/channel.rs
+++ b/libwebauthn/src/transport/ble/channel.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
 use std::time::Duration;
 
-use crate::fido::{FidoProtocol, FidoRevision};
+use crate::fido::FidoRevision;
 use crate::proto::ctap1::apdu::{ApduRequest, ApduResponse};
 use crate::proto::ctap2::cbor::{CborRequest, CborResponse};
 use crate::proto::CtapError;
@@ -40,7 +40,7 @@ impl<'a> BleChannel<'a> {
         let (ux_update_sender, _) = broadcast::channel(16);
 
         let revision = revisions
-            .select_protocol(FidoProtocol::U2F)
+            .select_best()
             .ok_or(Error::Transport(TransportError::NegotiationFailed))?;
         let connection = btleplug::connect(&device.btleplug_device.peripheral, &revision)
             .await


### PR DESCRIPTION
Fixes #27, adding support for FIDO over BLE.

No reason not to prefer FIDO2 when available.
