### PR TITLE
refactor(webauthn): use RequestOrigin instead of RelyingPartyId in WebAuthnIDL (fix #185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "libwebauthn"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aes",
  "apdu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fragile"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1823,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tungstenite",
+ "url",
  "uuid",
  "x509-parser",
 ]
@@ -2283,6 +2293,12 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -3597,6 +3613,18 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "utf-8"

--- a/libwebauthn-tests/tests/basic_ctap2.rs
+++ b/libwebauthn-tests/tests/basic_ctap2.rs
@@ -40,7 +40,7 @@ async fn test_webauthn_basic_ctap2() {
     let make_credentials_request = MakeCredentialRequest {
         challenge: Vec::from(challenge),
         origin: "example.org".to_owned(),
-        cross_origin: None,
+        top_origin: None,
         relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
         user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
         resident_key: Some(ResidentKeyRequirement::Discouraged),
@@ -66,7 +66,7 @@ async fn test_webauthn_basic_ctap2() {
         relying_party_id: "example.org".to_owned(),
         challenge: Vec::from(challenge),
         origin: "example.org".to_string(),
-        cross_origin: None,
+        top_origin: None,
         allow: vec![credential],
         user_verification: UserVerificationRequirement::Discouraged,
         extensions: Some(GetAssertionRequestExtensions::default()),

--- a/libwebauthn-tests/tests/preflight.rs
+++ b/libwebauthn-tests/tests/preflight.rs
@@ -49,7 +49,7 @@ async fn make_credential_call(
         exclude: exclude_list,
         extensions: None,
         timeout: TIMEOUT,
-        cross_origin: None,
+        top_origin: None,
     };
 
     let response = channel
@@ -71,7 +71,7 @@ async fn get_assertion_call(
         user_verification: UserVerificationRequirement::Discouraged,
         extensions: None,
         timeout: TIMEOUT,
-        cross_origin: None,
+        top_origin: None,
     };
 
     channel.webauthn_get_assertion(&get_assertion).await

--- a/libwebauthn-tests/tests/prf.rs
+++ b/libwebauthn-tests/tests/prf.rs
@@ -116,7 +116,7 @@ async fn run_test_battery(channel: &mut HidChannel<'_>, using_pin: bool) {
         exclude: None,
         extensions: Some(extensions),
         timeout: TIMEOUT,
-        cross_origin: None,
+        top_origin: None,
     };
 
     let state_recv = channel.get_ux_update_receiver();
@@ -175,7 +175,7 @@ async fn run_test_battery(channel: &mut HidChannel<'_>, using_pin: bool) {
         user_verification: UserVerificationRequirement::Preferred,
         extensions: None,
         timeout: TIMEOUT,
-        cross_origin: None,
+        top_origin: None,
     };
 
     let _response = channel
@@ -494,7 +494,7 @@ async fn run_success_test(
             ..Default::default()
         }),
         timeout: TIMEOUT,
-        cross_origin: None,
+        top_origin: None,
     };
 
     let response = channel
@@ -561,7 +561,7 @@ async fn run_failed_test(
             ..Default::default()
         }),
         timeout: TIMEOUT,
-        cross_origin: None,
+        top_origin: None,
     };
 
     let response: Result<(), WebAuthnError> = loop {

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -32,6 +32,7 @@ base64-url = "3.0.0"
 dbus = "0.9.5"
 tracing = "0.1.29"
 idna = "1.0.3"
+url = "2.5"
 maplit = "1.0.2"
 sha2 = "0.10.2"
 uuid = { version = "1.5.0", features = ["serde", "v4"] }

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libwebauthn"
 description = "FIDO2 (WebAuthn) and FIDO U2F platform library for Linux written in Rust "
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Alfie Fresta <alfie.fresta@gmail.com>"]
 edition = "2021"
 license-file = "../COPYING"

--- a/libwebauthn/examples/prf_test.rs
+++ b/libwebauthn/examples/prf_test.rs
@@ -149,7 +149,7 @@ async fn run_success_test(
         relying_party_id: "demo.yubico.com".to_owned(),
         challenge: Vec::from(challenge),
         origin: "demo.yubico.com".to_string(),
-        cross_origin: None,
+        top_origin: None,
         allow: vec![credential.clone()],
         user_verification: UserVerificationRequirement::Preferred,
         extensions: Some(GetAssertionRequestExtensions {

--- a/libwebauthn/examples/webauthn_cable.rs
+++ b/libwebauthn/examples/webauthn_cable.rs
@@ -130,7 +130,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         let make_credentials_request = MakeCredentialRequest {
             challenge: Vec::from(challenge),
             origin: "example.org".to_owned(),
-            cross_origin: None,
+            top_origin: None,
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
             resident_key: Some(ResidentKeyRequirement::Discouraged),
@@ -170,7 +170,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         relying_party_id: "example.org".to_owned(),
         challenge: Vec::from(challenge),
         origin: "example.org".to_string(),
-        cross_origin: None,
+        top_origin: None,
         allow: vec![credential],
         user_verification: UserVerificationRequirement::Discouraged,
         extensions: Some(GetAssertionRequestExtensions::default()),

--- a/libwebauthn/examples/webauthn_extensions_hid.rs
+++ b/libwebauthn/examples/webauthn_extensions_hid.rs
@@ -109,7 +109,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         let make_credentials_request = MakeCredentialRequest {
             challenge: Vec::from(challenge),
             origin: "example.org".to_owned(),
-            cross_origin: None,
+            top_origin: None,
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
             resident_key: Some(ResidentKeyRequirement::Required),
@@ -149,7 +149,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             relying_party_id: "example.org".to_owned(),
             challenge: Vec::from(challenge),
             origin: "example.org".to_string(),
-            cross_origin: None,
+            top_origin: None,
             allow: vec![credential],
             user_verification: UserVerificationRequirement::Discouraged,
             extensions: Some(GetAssertionRequestExtensions {

--- a/libwebauthn/examples/webauthn_hid.rs
+++ b/libwebauthn/examples/webauthn_hid.rs
@@ -121,7 +121,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         let make_credentials_request = MakeCredentialRequest {
             challenge: Vec::from(challenge),
             origin: "example.org".to_owned(),
-            cross_origin: None,
+            top_origin: None,
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
             resident_key: Some(ResidentKeyRequirement::Discouraged),
@@ -160,7 +160,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             relying_party_id: "example.org".to_owned(),
             challenge: Vec::from(challenge),
             origin: "example.org".to_string(),
-            cross_origin: None,
+            top_origin: None,
             allow: vec![credential],
             user_verification: UserVerificationRequirement::Discouraged,
             extensions: Some(GetAssertionRequestExtensions::default()),

--- a/libwebauthn/examples/webauthn_json_hid.rs
+++ b/libwebauthn/examples/webauthn_json_hid.rs
@@ -8,7 +8,7 @@ use tokio::sync::broadcast::Receiver;
 use tracing_subscriber::{self, EnvFilter};
 
 use libwebauthn::ops::webauthn::{
-    GetAssertionRequest, JsonFormat, MakeCredentialRequest, RelyingPartyId, WebAuthnIDL as _,
+    GetAssertionRequest, JsonFormat, MakeCredentialRequest, RequestOrigin, WebAuthnIDL as _,
     WebAuthnIDLResponse as _,
 };
 use libwebauthn::pin::PinRequestReason;
@@ -79,7 +79,8 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         let mut channel = device.channel().await?;
         channel.wink(TIMEOUT).await?;
 
-        let rpid = RelyingPartyId("example.org".to_owned());
+        let request_origin: RequestOrigin =
+            "https://example.org".try_into().expect("Invalid origin");
         let request_json = r#"
                 {
                     "rp": {
@@ -105,7 +106,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                 }
                 "#;
         let make_credentials_request: MakeCredentialRequest =
-            MakeCredentialRequest::from_json(&rpid, request_json)
+            MakeCredentialRequest::from_json(&request_origin, request_json)
                 .expect("Failed to parse request JSON");
         println!(
             "WebAuthn MakeCredential request: {:?}",
@@ -157,7 +158,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                 }
                 "#;
         let get_assertion: GetAssertionRequest =
-            GetAssertionRequest::from_json(&rpid, request_json)
+            GetAssertionRequest::from_json(&request_origin, request_json)
                 .expect("Failed to parse request JSON");
         println!("WebAuthn GetAssertion request: {:?}", get_assertion);
 

--- a/libwebauthn/examples/webauthn_nfc.rs
+++ b/libwebauthn/examples/webauthn_nfc.rs
@@ -122,7 +122,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         let make_credentials_request = MakeCredentialRequest {
             challenge: Vec::from(challenge),
             origin: "example.org".to_owned(),
-            cross_origin: None,
+            top_origin: None,
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
             resident_key: Some(ResidentKeyRequirement::Discouraged),
@@ -161,7 +161,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             relying_party_id: "example.org".to_owned(),
             challenge: Vec::from(challenge),
             origin: "example.org".to_owned(),
-            cross_origin: None,
+            top_origin: None,
             allow: vec![credential],
             user_verification: UserVerificationRequirement::Discouraged,
             extensions: None,

--- a/libwebauthn/examples/webauthn_preflight_hid.rs
+++ b/libwebauthn/examples/webauthn_preflight_hid.rs
@@ -164,7 +164,7 @@ async fn make_credential_call(
     let make_credentials_request = MakeCredentialRequest {
         challenge: Vec::from(challenge),
         origin: "example.org".to_owned(),
-        cross_origin: None,
+        top_origin: None,
         relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
         user: Ctap2PublicKeyCredentialUserEntity::new(user_id, "mario.rossi", "Mario Rossi"),
         resident_key: Some(ResidentKeyRequirement::Discouraged),
@@ -203,7 +203,7 @@ async fn get_assertion_call(
         relying_party_id: "example.org".to_owned(),
         challenge: Vec::from(challenge),
         origin: "example.org".to_string(),
-        cross_origin: None,
+        top_origin: None,
         allow: allow_list,
         user_verification: UserVerificationRequirement::Discouraged,
         extensions: Some(GetAssertionRequestExtensions::default()),

--- a/libwebauthn/examples/webauthn_prf_hid.rs
+++ b/libwebauthn/examples/webauthn_prf_hid.rs
@@ -103,7 +103,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         let make_credentials_request = MakeCredentialRequest {
             challenge: Vec::from(challenge),
             origin: "example.org".to_owned(),
-            cross_origin: None,
+            top_origin: None,
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(&user_id, "mario.rossi", "Mario Rossi"),
             resident_key: Some(ResidentKeyRequirement::Required),
@@ -421,7 +421,7 @@ async fn run_success_test(
         relying_party_id: "example.org".to_owned(),
         challenge: Vec::from(challenge),
         origin: "example.org".to_string(),
-        cross_origin: None,
+        top_origin: None,
         allow: vec![credential.clone()],
         user_verification: UserVerificationRequirement::Discouraged,
         extensions: Some(GetAssertionRequestExtensions {
@@ -465,7 +465,7 @@ async fn run_failed_test(
         relying_party_id: "example.org".to_owned(),
         challenge: Vec::from(challenge),
         origin: "example.org".to_string(),
-        cross_origin: None,
+        top_origin: None,
         allow: credential.map(|x| vec![x.clone()]).unwrap_or_default(),
         user_verification: UserVerificationRequirement::Discouraged,
         extensions: Some(GetAssertionRequestExtensions {

--- a/libwebauthn/src/ops/u2f.rs
+++ b/libwebauthn/src/ops/u2f.rs
@@ -215,7 +215,7 @@ impl UpgradableResponse<GetAssertionResponse, SignRequest> for SignResponse {
             relying_party_id: String::new(), // We don't have access to that info here, but we don't need it either
             challenge: Vec::new(), // U2F path doesn't use client_data for response serialization
             origin: String::new(),
-            cross_origin: None,
+            top_origin: None,
             allow: vec![Ctap2PublicKeyCredentialDescriptor {
                 r#type: Ctap2PublicKeyCredentialType::PublicKey,
                 id: request.key_handle.clone().into(),

--- a/libwebauthn/src/ops/webauthn/client_data.rs
+++ b/libwebauthn/src/ops/webauthn/client_data.rs
@@ -9,8 +9,8 @@ pub struct ClientData {
     pub operation: Operation,
     pub challenge: Vec<u8>,
     pub origin: String,
-    pub cross_origin: Option<bool>,
-    /// The origin of the top-level document, if in an iframe.
+    /// The origin of the top-level document, if the request was made in a
+    /// cross-origin nested browsing context (e.g. an iframe).
     /// https://www.w3.org/TR/webauthn-3/#dom-collectedclientdata-toporigin
     pub top_origin: Option<String>,
 }
@@ -24,12 +24,19 @@ impl ClientData {
         };
         let challenge_str = base64_url::encode(&self.challenge);
         let origin_str = &self.origin;
-        let cross_origin_str = if self.cross_origin.unwrap_or(false) {
+        let cross_origin_str = if self.top_origin.is_some() {
             "true"
         } else {
             "false"
         };
-        format!("{{\"type\":\"{op_str}\",\"challenge\":\"{challenge_str}\",\"origin\":\"{origin_str}\",\"crossOrigin\":{cross_origin_str}}}")
+        match &self.top_origin {
+            Some(top) => format!(
+                "{{\"type\":\"{op_str}\",\"challenge\":\"{challenge_str}\",\"origin\":\"{origin_str}\",\"crossOrigin\":{cross_origin_str},\"topOrigin\":\"{top}\"}}"
+            ),
+            None => format!(
+                "{{\"type\":\"{op_str}\",\"challenge\":\"{challenge_str}\",\"origin\":\"{origin_str}\",\"crossOrigin\":{cross_origin_str}}}"
+            ),
+        }
     }
 
     pub fn hash(&self) -> Vec<u8> {
@@ -44,65 +51,56 @@ impl ClientData {
 mod tests {
     use super::*;
 
-    fn make_client_data(cross_origin: Option<bool>) -> ClientData {
+    fn make_client_data(top_origin: Option<String>) -> ClientData {
         ClientData {
             operation: Operation::GetAssertion,
             challenge: b"test-challenge".to_vec(),
             origin: "https://example.org".to_string(),
-            cross_origin,
-            top_origin: None,
+            top_origin,
         }
     }
 
     #[test]
-    fn test_cross_origin_none_produces_false() {
+    fn same_origin_emits_cross_origin_false() {
         let client_data = make_client_data(None);
         let json = client_data.to_json();
         assert!(
             json.contains("\"crossOrigin\":false"),
-            "Expected crossOrigin:false, got: {}",
-            json
+            "Expected crossOrigin:false, got: {json}"
         );
-    }
-
-    #[test]
-    fn test_cross_origin_false_produces_false() {
-        let client_data = make_client_data(Some(false));
-        let json = client_data.to_json();
         assert!(
-            json.contains("\"crossOrigin\":false"),
-            "Expected crossOrigin:false, got: {}",
-            json
+            !json.contains("topOrigin"),
+            "Did not expect topOrigin, got: {json}"
         );
     }
 
     #[test]
-    fn test_cross_origin_true_produces_true() {
-        let client_data = make_client_data(Some(true));
+    fn cross_origin_emits_cross_origin_true_and_top_origin() {
+        let client_data = make_client_data(Some("https://top.example.org".to_string()));
         let json = client_data.to_json();
         assert!(
             json.contains("\"crossOrigin\":true"),
-            "Expected crossOrigin:true, got: {}",
-            json
+            "Expected crossOrigin:true, got: {json}"
+        );
+        assert!(
+            json.contains("\"topOrigin\":\"https://top.example.org\""),
+            "Expected topOrigin, got: {json}"
         );
     }
 
     #[test]
-    fn test_to_json_format() {
+    fn to_json_format() {
         let client_data = ClientData {
             operation: Operation::MakeCredential,
             challenge: b"DEADCODE".to_vec(),
             origin: "https://example.org".to_string(),
-            cross_origin: Some(true),
             top_origin: None,
         };
         let json = client_data.to_json();
 
-        // Verify the JSON contains expected structure
         assert!(json.contains("\"type\":\"webauthn.create\""));
         assert!(json.contains("\"origin\":\"https://example.org\""));
-        assert!(json.contains("\"crossOrigin\":true"));
-        // Challenge should be base64url encoded
-        assert!(json.contains("\"challenge\":\"REVBRENPREU\"")); // base64url of "DEADCODE"
+        assert!(json.contains("\"crossOrigin\":false"));
+        assert!(json.contains("\"challenge\":\"REVBRENPREU\""));
     }
 }

--- a/libwebauthn/src/ops/webauthn/get_assertion.rs
+++ b/libwebauthn/src/ops/webauthn/get_assertion.rs
@@ -46,7 +46,9 @@ pub struct GetAssertionRequest {
     pub relying_party_id: String,
     pub challenge: Vec<u8>,
     pub origin: String,
-    pub cross_origin: Option<bool>,
+    /// The top-level origin if the request was made from a cross-origin
+    /// nested browsing context. None for same-origin requests.
+    pub top_origin: Option<String>,
     pub allow: Vec<Ctap2PublicKeyCredentialDescriptor>,
     pub extensions: Option<GetAssertionRequestExtensions>,
     pub user_verification: UserVerificationRequirement,
@@ -59,8 +61,7 @@ impl GetAssertionRequest {
             operation: Operation::GetAssertion,
             challenge: self.challenge.clone(),
             origin: self.origin.clone(),
-            cross_origin: self.cross_origin,
-            top_origin: None,
+            top_origin: self.top_origin.clone(),
         }
     }
 
@@ -157,7 +158,7 @@ impl FromIdlModel<PublicKeyCredentialRequestOptionsJSON, GetAssertionRequestPars
             relying_party_id: rpid.to_string(),
             challenge: inner.challenge.to_vec(),
             origin: rpid.to_string(),
-            cross_origin: None,
+            top_origin: None,
             allow: inner
                 .allow_credentials
                 .into_iter()
@@ -597,7 +598,7 @@ mod tests {
             relying_party_id: "example.org".to_owned(),
             challenge: base64_url::decode("Y3JlZGVudGlhbHMtZm9yLWxpbnV4L2xpYndlYmF1dGhu").unwrap(),
             origin: "example.org".to_string(),
-            cross_origin: None,
+            top_origin: None,
             allow: vec![Ctap2PublicKeyCredentialDescriptor {
                 r#type: Ctap2PublicKeyCredentialType::PublicKey,
                 id: ByteBuf::from(base64_url::decode("bXktY3JlZGVudGlhbC1pZA").unwrap()),
@@ -772,7 +773,7 @@ mod tests {
             relying_party_id: "example.org".to_owned(),
             challenge: b"DEADCODE_challenge".to_vec(),
             origin: "example.org".to_string(),
-            cross_origin: None,
+            top_origin: None,
             allow: vec![],
             extensions: None,
             user_verification: UserVerificationRequirement::Preferred,

--- a/libwebauthn/src/ops/webauthn/get_assertion.rs
+++ b/libwebauthn/src/ops/webauthn/get_assertion.rs
@@ -31,7 +31,9 @@ use crate::{
 };
 
 use super::timeout::DEFAULT_TIMEOUT;
-use super::{DowngradableRequest, RelyingPartyId, SignRequest, UserVerificationRequirement};
+use super::{
+    DowngradableRequest, RelyingPartyId, RequestOrigin, SignRequest, UserVerificationRequirement,
+};
 
 #[derive(Debug, Default, Clone, Serialize, PartialEq)]
 pub struct PRFValue {
@@ -112,18 +114,19 @@ impl FromIdlModel<PublicKeyCredentialRequestOptionsJSON, GetAssertionRequestPars
     for GetAssertionRequest
 {
     fn from_idl_model(
-        rpid: &RelyingPartyId,
+        request_origin: &RequestOrigin,
         inner: PublicKeyCredentialRequestOptionsJSON,
     ) -> Result<Self, GetAssertionRequestParsingError> {
+        let effective_rp_id = request_origin.origin.host.as_str();
         if let Some(relying_party_id) = inner.relying_party_id.as_deref() {
             let parsed = RelyingPartyId::try_from(relying_party_id).map_err(|err| {
                 GetAssertionRequestParsingError::InvalidRelyingPartyId(err.to_string())
             })?;
             // TODO(#160): Add support for related origin per WebAuthn Level 3.
-            if parsed.0 != rpid.0 {
+            if parsed.0 != effective_rp_id {
                 return Err(GetAssertionRequestParsingError::MismatchingRelyingPartyId(
                     parsed.0,
-                    rpid.0.to_string(),
+                    effective_rp_id.to_string(),
                 ));
             }
         }
@@ -155,10 +158,10 @@ impl FromIdlModel<PublicKeyCredentialRequestOptionsJSON, GetAssertionRequestPars
             .unwrap_or(DEFAULT_TIMEOUT);
 
         Ok(GetAssertionRequest {
-            relying_party_id: rpid.to_string(),
+            relying_party_id: effective_rp_id.to_string(),
             challenge: inner.challenge.to_vec(),
-            origin: rpid.to_string(),
-            top_origin: None,
+            origin: request_origin.origin.to_string(),
+            top_origin: request_origin.top_origin.as_ref().map(|o| o.to_string()),
             allow: inner
                 .allow_credentials
                 .into_iter()
@@ -572,8 +575,7 @@ mod tests {
 
     use serde_bytes::ByteBuf;
 
-    use crate::ops::webauthn::GetAssertionRequest;
-    use crate::ops::webauthn::RelyingPartyId;
+    use crate::ops::webauthn::{GetAssertionRequest, RequestOrigin};
     use crate::proto::ctap2::Ctap2PublicKeyCredentialType;
 
     use super::*;
@@ -597,7 +599,7 @@ mod tests {
         GetAssertionRequest {
             relying_party_id: "example.org".to_owned(),
             challenge: base64_url::decode("Y3JlZGVudGlhbHMtZm9yLWxpbnV4L2xpYndlYmF1dGhu").unwrap(),
-            origin: "example.org".to_string(),
+            origin: "https://example.org".to_string(),
             top_origin: None,
             allow: vec![Ctap2PublicKeyCredentialDescriptor {
                 r#type: Ctap2PublicKeyCredentialType::PublicKey,
@@ -626,27 +628,28 @@ mod tests {
 
     #[test]
     fn test_request_from_json_base() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req: GetAssertionRequest =
-            GetAssertionRequest::from_json(&rpid, REQUEST_BASE_JSON).unwrap();
+            GetAssertionRequest::from_json(&request_origin, REQUEST_BASE_JSON).unwrap();
         assert_eq!(req, request_base());
     }
 
     #[test]
     fn test_request_from_json_ignore_missing_rp_id() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_rm(REQUEST_BASE_JSON, "rpId");
 
-        let req: GetAssertionRequest = GetAssertionRequest::from_json(&rpid, &req_json).unwrap();
+        let req: GetAssertionRequest =
+            GetAssertionRequest::from_json(&request_origin, &req_json).unwrap();
         assert_eq!(req, request_base());
     }
 
     #[test]
     fn test_request_from_json_invalid_rp_id() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_add(REQUEST_BASE_JSON, "rpId", r#""example.org.""#);
 
-        let result = GetAssertionRequest::from_json(&rpid, &req_json);
+        let result = GetAssertionRequest::from_json(&request_origin, &req_json);
         assert!(matches!(
             result,
             Err(GetAssertionRequestParsingError::InvalidRelyingPartyId(_))
@@ -655,10 +658,10 @@ mod tests {
 
     #[test]
     fn test_request_from_json_mismatching_rp_id() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_add(REQUEST_BASE_JSON, "rpId", r#""other.example.org""#);
 
-        let result = GetAssertionRequest::from_json(&rpid, &req_json);
+        let result = GetAssertionRequest::from_json(&request_origin, &req_json);
         assert!(matches!(
             result,
             Err(GetAssertionRequestParsingError::MismatchingRelyingPartyId(
@@ -670,10 +673,11 @@ mod tests {
 
     #[test]
     fn test_request_from_json_ignore_missing_allow_credentials() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_rm(REQUEST_BASE_JSON, "allowCredentials");
 
-        let req: GetAssertionRequest = GetAssertionRequest::from_json(&rpid, &req_json).unwrap();
+        let req: GetAssertionRequest =
+            GetAssertionRequest::from_json(&request_origin, &req_json).unwrap();
         assert_eq!(
             req,
             GetAssertionRequest {
@@ -685,10 +689,11 @@ mod tests {
 
     #[test]
     fn test_request_from_json_default_timeout() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_rm(REQUEST_BASE_JSON, "timeout");
 
-        let req: GetAssertionRequest = GetAssertionRequest::from_json(&rpid, &req_json).unwrap();
+        let req: GetAssertionRequest =
+            GetAssertionRequest::from_json(&request_origin, &req_json).unwrap();
         assert_eq!(req.timeout, DEFAULT_TIMEOUT);
     }
 
@@ -697,10 +702,11 @@ mod tests {
         // Test that "extensions": {} results in Some(default) not None
         // This is important for strict portals that distinguish between
         // no extensions key vs empty extensions object
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_add(REQUEST_BASE_JSON, "extensions", r#"{}"#);
 
-        let req: GetAssertionRequest = GetAssertionRequest::from_json(&rpid, &req_json).unwrap();
+        let req: GetAssertionRequest =
+            GetAssertionRequest::from_json(&request_origin, &req_json).unwrap();
         assert_eq!(
             req.extensions,
             Some(GetAssertionRequestExtensions::default())
@@ -710,14 +716,15 @@ mod tests {
     #[test]
     #[ignore] // FIXME(#134) allow arbitrary size input
     fn test_request_from_json_prf_extension() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_add(
             REQUEST_BASE_JSON,
             "extensions",
             r#"{"prf":{"eval":{"first": "second"}}}"#,
         );
 
-        let req: GetAssertionRequest = GetAssertionRequest::from_json(&rpid, &req_json).unwrap();
+        let req: GetAssertionRequest =
+            GetAssertionRequest::from_json(&request_origin, &req_json).unwrap();
         if let Some(GetAssertionRequestExtensions {
             prf:
                 Some(PrfInput {

--- a/libwebauthn/src/ops/webauthn/idl/mod.rs
+++ b/libwebauthn/src/ops/webauthn/idl/mod.rs
@@ -14,7 +14,7 @@ pub use response::{
     WebAuthnIDLResponse,
 };
 
-use rpid::RelyingPartyId;
+use origin::RequestOrigin;
 
 use serde::de::DeserializeOwned;
 use serde_json;
@@ -33,9 +33,9 @@ where
     /// The JSON model that this IDL can deserialize from.
     type IdlModel: DeserializeOwned;
 
-    fn from_json(rpid: &RelyingPartyId, json: &str) -> Result<Self, Self::Error> {
+    fn from_json(request_origin: &RequestOrigin, json: &str) -> Result<Self, Self::Error> {
         let idl_model: Self::IdlModel = serde_json::from_str(json)?;
-        Self::from_idl_model(rpid, idl_model).map_err(From::from)
+        Self::from_idl_model(request_origin, idl_model).map_err(From::from)
     }
 }
 
@@ -44,5 +44,5 @@ where
     T: DeserializeOwned,
     E: std::error::Error,
 {
-    fn from_idl_model(rpid: &RelyingPartyId, model: T) -> Result<Self, E>;
+    fn from_idl_model(request_origin: &RequestOrigin, model: T) -> Result<Self, E>;
 }

--- a/libwebauthn/src/ops/webauthn/idl/mod.rs
+++ b/libwebauthn/src/ops/webauthn/idl/mod.rs
@@ -1,6 +1,7 @@
 mod base64url;
 pub mod create;
 pub mod get;
+pub mod origin;
 pub mod response;
 pub mod rpid;
 

--- a/libwebauthn/src/ops/webauthn/idl/origin.rs
+++ b/libwebauthn/src/ops/webauthn/idl/origin.rs
@@ -1,0 +1,359 @@
+use std::convert::TryFrom;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use url::Host;
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum HostParseError {
+    #[error("empty host")]
+    Empty,
+    #[error("invalid IP address: {0}")]
+    InvalidIp(String),
+    #[error("invalid domain: {0}")]
+    InvalidDomain(String),
+}
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum OriginParseError {
+    #[error("invalid scheme (only https is supported)")]
+    InvalidScheme,
+    #[error("missing host")]
+    MissingHost,
+    #[error("invalid host: {0}")]
+    InvalidHost(#[from] HostParseError),
+    #[error("invalid port: {0}")]
+    InvalidPort(String),
+    #[error("unexpected path or fragment: {0}")]
+    UnexpectedPath(String),
+}
+
+/// Validated host component of an HTTPS origin.
+///
+/// Parsing follows the WHATWG URL Standard host parser via [`url::Host`], which
+/// accepts ASCII / IDNA domains, IPv4 literals, and bracketed IPv6 literals,
+/// and rejects everything else.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OriginHost(String);
+
+impl OriginHost {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for OriginHost {
+    type Err = HostParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(HostParseError::Empty);
+        }
+        match Host::parse(s) {
+            Ok(h) => Ok(OriginHost(h.to_string())),
+            Err(err) => {
+                let msg = err.to_string();
+                if msg.contains("IPv4") || msg.contains("ipv4") {
+                    Err(HostParseError::InvalidIp(msg))
+                } else if msg.contains("IPv6") || msg.contains("ipv6") {
+                    Err(HostParseError::InvalidIp(msg))
+                } else {
+                    Err(HostParseError::InvalidDomain(msg))
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<&str> for OriginHost {
+    type Error = HostParseError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::from_str(s)
+    }
+}
+
+impl Display for OriginHost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// An HTTPS origin: scheme is implicit, port optional.
+///
+/// Note: an enum variant for `https` is intentionally not used here since we
+/// only support a single scheme. If we ever need additional schemes (e.g.
+/// `app:` for AppId-style origins) this can become an enum without breaking
+/// the field-access pattern at call sites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Origin {
+    pub host: OriginHost,
+    pub port: Option<u16>,
+}
+
+impl Origin {
+    pub fn new(host: OriginHost, port: Option<u16>) -> Self {
+        Self { host, port }
+    }
+}
+
+impl Display for Origin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "https://{}", self.host)?;
+        if let Some(port) = self.port {
+            write!(f, ":{port}")?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for Origin {
+    type Err = OriginParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rest = s
+            .strip_prefix("https://")
+            .ok_or(OriginParseError::InvalidScheme)?;
+
+        if rest.is_empty() {
+            return Err(OriginParseError::MissingHost);
+        }
+
+        let (authority, tail_marker) = rest
+            .find(['/', '?', '#'])
+            .map(|idx| (&rest[..idx], Some(&rest[idx..])))
+            .unwrap_or((rest, None));
+
+        if let Some(tail) = tail_marker {
+            // Allow a trailing slash with nothing after it; reject anything more.
+            if tail != "/" {
+                return Err(OriginParseError::UnexpectedPath(tail.to_string()));
+            }
+        }
+
+        let (host_str, port) = split_host_and_port(authority)?;
+        let host = OriginHost::from_str(host_str)?;
+        Ok(Origin { host, port })
+    }
+}
+
+impl TryFrom<&str> for Origin {
+    type Error = OriginParseError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::from_str(s)
+    }
+}
+
+fn split_host_and_port(s: &str) -> Result<(&str, Option<u16>), OriginParseError> {
+    // IPv6 literals are bracketed. Find the matching `]` first if present so
+    // we don't confuse `:` inside the address with the host/port separator.
+    if let Some(stripped) = s.strip_prefix('[') {
+        let end = stripped
+            .find(']')
+            .ok_or_else(|| OriginParseError::InvalidHost(HostParseError::InvalidIp(s.to_string())))?;
+        let host = &s[..end + 2]; // include the brackets
+        let after = &s[end + 2..];
+        if after.is_empty() {
+            return Ok((host, None));
+        }
+        let port_str = after
+            .strip_prefix(':')
+            .ok_or_else(|| OriginParseError::InvalidPort(after.to_string()))?;
+        let port = port_str
+            .parse::<u16>()
+            .map_err(|_| OriginParseError::InvalidPort(port_str.to_string()))?;
+        return Ok((host, Some(port)));
+    }
+
+    match s.rsplit_once(':') {
+        Some((host, port_str)) => {
+            let port = port_str
+                .parse::<u16>()
+                .map_err(|_| OriginParseError::InvalidPort(port_str.to_string()))?;
+            Ok((host, Some(port)))
+        }
+        None => Ok((s, None)),
+    }
+}
+
+/// The origin context of an incoming WebAuthn request: the request's own
+/// origin, plus the top-level origin when the request was made from a nested
+/// (cross-origin) browsing context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestOrigin {
+    pub origin: Origin,
+    pub top_origin: Option<Origin>,
+}
+
+impl RequestOrigin {
+    /// Same-origin request: no top-level origin.
+    pub fn new(origin: Origin) -> Self {
+        Self {
+            origin,
+            top_origin: None,
+        }
+    }
+
+    /// Cross-origin request: the request was made from a nested browsing
+    /// context whose top-level origin is `top_origin`.
+    pub fn new_cross_origin(origin: Origin, top_origin: Origin) -> Self {
+        Self {
+            origin,
+            top_origin: Some(top_origin),
+        }
+    }
+
+    /// True iff the request was made from a nested browsing context with a
+    /// different top-level origin.
+    pub fn is_cross_origin(&self) -> bool {
+        self.top_origin.is_some()
+    }
+}
+
+impl FromStr for RequestOrigin {
+    type Err = OriginParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(Origin::from_str(s)?))
+    }
+}
+
+impl TryFrom<&str> for RequestOrigin {
+    type Error = OriginParseError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Self::from_str(s)
+    }
+}
+
+impl TryFrom<String> for RequestOrigin {
+    type Error = OriginParseError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::from_str(&s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_parses_domain() {
+        let h: OriginHost = "example.org".parse().unwrap();
+        assert_eq!(h.as_str(), "example.org");
+    }
+
+    #[test]
+    fn host_idna_normalises() {
+        let h: OriginHost = "例え.テスト".parse().unwrap();
+        assert_eq!(h.as_str(), "xn--r8jz45g.xn--zckzah");
+    }
+
+    #[test]
+    fn host_accepts_ipv4() {
+        let h: OriginHost = "127.0.0.1".parse().unwrap();
+        assert_eq!(h.as_str(), "127.0.0.1");
+    }
+
+    #[test]
+    fn host_accepts_bracketed_ipv6() {
+        let h: OriginHost = "[::1]".parse().unwrap();
+        assert_eq!(h.as_str(), "[::1]");
+    }
+
+    #[test]
+    fn host_rejects_empty() {
+        assert!(matches!(
+            "".parse::<OriginHost>(),
+            Err(HostParseError::Empty)
+        ));
+    }
+
+    #[test]
+    fn origin_parses_bare_host() {
+        let o: Origin = "https://example.org".parse().unwrap();
+        assert_eq!(o.host.as_str(), "example.org");
+        assert_eq!(o.port, None);
+        assert_eq!(o.to_string(), "https://example.org");
+    }
+
+    #[test]
+    fn origin_parses_host_with_port() {
+        let o: Origin = "https://example.org:8443".parse().unwrap();
+        assert_eq!(o.host.as_str(), "example.org");
+        assert_eq!(o.port, Some(8443));
+        assert_eq!(o.to_string(), "https://example.org:8443");
+    }
+
+    #[test]
+    fn origin_parses_ipv6_with_port() {
+        let o: Origin = "https://[::1]:8443".parse().unwrap();
+        assert_eq!(o.host.as_str(), "[::1]");
+        assert_eq!(o.port, Some(8443));
+        assert_eq!(o.to_string(), "https://[::1]:8443");
+    }
+
+    #[test]
+    fn origin_allows_trailing_slash() {
+        let o: Origin = "https://example.org/".parse().unwrap();
+        assert_eq!(o.to_string(), "https://example.org");
+    }
+
+    #[test]
+    fn origin_rejects_non_https() {
+        assert!(matches!(
+            "http://example.org".parse::<Origin>(),
+            Err(OriginParseError::InvalidScheme)
+        ));
+    }
+
+    #[test]
+    fn origin_rejects_path() {
+        assert!(matches!(
+            "https://example.org/foo".parse::<Origin>(),
+            Err(OriginParseError::UnexpectedPath(_))
+        ));
+    }
+
+    #[test]
+    fn origin_rejects_query() {
+        assert!(matches!(
+            "https://example.org?x=1".parse::<Origin>(),
+            Err(OriginParseError::UnexpectedPath(_))
+        ));
+    }
+
+    #[test]
+    fn origin_rejects_invalid_port() {
+        assert!(matches!(
+            "https://example.org:notaport".parse::<Origin>(),
+            Err(OriginParseError::InvalidPort(_))
+        ));
+    }
+
+    #[test]
+    fn request_origin_same_origin() {
+        let r: RequestOrigin = "https://example.org".parse().unwrap();
+        assert!(!r.is_cross_origin());
+        assert_eq!(r.top_origin, None);
+    }
+
+    #[test]
+    fn request_origin_cross_origin() {
+        let inner: Origin = "https://embed.example.org".parse().unwrap();
+        let top: Origin = "https://example.org".parse().unwrap();
+        let r = RequestOrigin::new_cross_origin(inner.clone(), top.clone());
+        assert!(r.is_cross_origin());
+        assert_eq!(r.origin, inner);
+        assert_eq!(r.top_origin, Some(top));
+    }
+
+    #[test]
+    fn request_origin_try_from_string() {
+        let r = RequestOrigin::try_from("https://example.org:443".to_string()).unwrap();
+        assert_eq!(r.origin.host.as_str(), "example.org");
+        assert_eq!(r.origin.port, Some(443));
+    }
+}

--- a/libwebauthn/src/ops/webauthn/idl/origin.rs
+++ b/libwebauthn/src/ops/webauthn/idl/origin.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-use url::Host;
+use url::{Host, ParseError, Url};
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum HostParseError {
@@ -16,8 +16,10 @@ pub enum HostParseError {
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum OriginParseError {
-    #[error("invalid scheme (only https is supported)")]
+    #[error("invalid scheme (only https, or http with localhost, is supported)")]
     InvalidScheme,
+    #[error("http scheme is only allowed for localhost, got {0}")]
+    InsecureHttpHost(String),
     #[error("missing host")]
     MissingHost,
     #[error("invalid host: {0}")]
@@ -26,6 +28,8 @@ pub enum OriginParseError {
     InvalidPort(String),
     #[error("unexpected path or fragment: {0}")]
     UnexpectedPath(String),
+    #[error("origin must not contain userinfo")]
+    UnexpectedUserinfo,
 }
 
 /// Validated host component of an HTTPS origin.
@@ -49,18 +53,14 @@ impl FromStr for OriginHost {
         if s.is_empty() {
             return Err(HostParseError::Empty);
         }
-        match Host::parse(s) {
-            Ok(h) => Ok(OriginHost(h.to_string())),
-            Err(err) => {
-                let msg = err.to_string();
-                let lower = msg.to_lowercase();
-                if lower.contains("ipv4") || lower.contains("ipv6") {
-                    Err(HostParseError::InvalidIp(msg))
-                } else {
-                    Err(HostParseError::InvalidDomain(msg))
+        Host::parse(s)
+            .map(|h| OriginHost(h.to_string()))
+            .map_err(|err| match err {
+                ParseError::InvalidIpv4Address | ParseError::InvalidIpv6Address => {
+                    HostParseError::InvalidIp(err.to_string())
                 }
-            }
-        }
+                _ => HostParseError::InvalidDomain(err.to_string()),
+            })
     }
 }
 
@@ -78,27 +78,56 @@ impl Display for OriginHost {
     }
 }
 
-/// An HTTPS origin: scheme is implicit, port optional.
+/// Scheme of a WebAuthn origin.
 ///
-/// Note: an enum variant for `https` is intentionally not used here since we
-/// only support a single scheme. If we ever need additional schemes (e.g.
-/// `app:` for AppId-style origins) this can become an enum without breaking
-/// the field-access pattern at call sites.
+/// `Https` is the standard case. `Http` is permitted only with the literal
+/// `localhost` host, because Web specs (Secure Contexts) treat
+/// `http://localhost` as a secure context for development purposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scheme {
+    Https,
+    Http,
+}
+
+impl Scheme {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Scheme::Https => "https",
+            Scheme::Http => "http",
+        }
+    }
+}
+
+impl Display for Scheme {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A WebAuthn origin. The scheme is `https`, or `http` only when the host is
+/// the literal `localhost`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Origin {
+    pub scheme: Scheme,
     pub host: OriginHost,
     pub port: Option<u16>,
 }
 
 impl Origin {
+    /// Constructs an HTTPS origin. Use [`Origin::from_str`] to parse an
+    /// arbitrary origin string (which will also accept `http://localhost`).
     pub fn new(host: OriginHost, port: Option<u16>) -> Self {
-        Self { host, port }
+        Self {
+            scheme: Scheme::Https,
+            host,
+            port,
+        }
     }
 }
 
 impl Display for Origin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "https://{}", self.host)?;
+        write!(f, "{}://{}", self.scheme, self.host)?;
         if let Some(port) = self.port {
             write!(f, ":{port}")?;
         }
@@ -106,33 +135,74 @@ impl Display for Origin {
     }
 }
 
+/// Returns true iff `host` qualifies for the `http://` scheme. The W3C Secure
+/// Contexts spec considers a broader set of hosts trustworthy (`localhost`,
+/// `*.localhost`, `127.0.0.0/8`, `[::1]`). We intentionally restrict to the
+/// literal `localhost` here as the minimum dev affordance; this can be
+/// widened later without breaking existing callers.
+///
+/// Case comparison is safe: [`url::Host::parse`] ASCII-lowercases the domain
+/// during parsing, so `LOCALHOST` and `localhost` both compare equal here.
+fn host_allows_http(host: &OriginHost) -> bool {
+    host.as_str() == "localhost"
+}
+
 impl FromStr for Origin {
     type Err = OriginParseError;
 
+    /// Parses a WebAuthn origin from a string. Delegates to [`url::Url`] for
+    /// scheme, host (including IDNA / IPv4 / IPv6), and port parsing, then
+    /// applies WebAuthn-specific rules:
+    ///
+    /// * scheme must be `https`, or `http` when the host is the literal
+    ///   `localhost`
+    /// * no userinfo (`user:pw@host`)
+    /// * no path beyond `/`, no query, no fragment
+    ///
+    /// Per the WHATWG URL Standard, default ports (e.g. `:443` for https)
+    /// are dropped during parsing, matching the canonical origin form used
+    /// in `clientDataJSON.origin`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let rest = s
-            .strip_prefix("https://")
-            .ok_or(OriginParseError::InvalidScheme)?;
+        let url = Url::parse(s).map_err(map_url_parse_error)?;
 
-        if rest.is_empty() {
-            return Err(OriginParseError::MissingHost);
+        let scheme = match url.scheme() {
+            "https" => Scheme::Https,
+            "http" => Scheme::Http,
+            _ => return Err(OriginParseError::InvalidScheme),
+        };
+
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(OriginParseError::UnexpectedUserinfo);
+        }
+        if !matches!(url.path(), "" | "/") {
+            return Err(OriginParseError::UnexpectedPath(url.path().to_string()));
+        }
+        if let Some(q) = url.query() {
+            return Err(OriginParseError::UnexpectedPath(format!("?{q}")));
+        }
+        if let Some(f) = url.fragment() {
+            return Err(OriginParseError::UnexpectedPath(format!("#{f}")));
         }
 
-        let (authority, tail_marker) = rest
-            .find(['/', '?', '#'])
-            .map(|idx| (&rest[..idx], Some(&rest[idx..])))
-            .unwrap_or((rest, None));
+        let host = match url.host() {
+            Some(Host::Domain(d)) => OriginHost(d.to_string()),
+            Some(Host::Ipv4(ip)) => OriginHost(ip.to_string()),
+            // Restore the brackets that `url::Url` strips off internally.
+            Some(Host::Ipv6(ip)) => OriginHost(format!("[{ip}]")),
+            None => return Err(OriginParseError::MissingHost),
+        };
 
-        if let Some(tail) = tail_marker {
-            // Allow a trailing slash with nothing after it; reject anything more.
-            if tail != "/" {
-                return Err(OriginParseError::UnexpectedPath(tail.to_string()));
-            }
+        if matches!(scheme, Scheme::Http) && !host_allows_http(&host) {
+            return Err(OriginParseError::InsecureHttpHost(
+                host.as_str().to_string(),
+            ));
         }
 
-        let (host_str, port) = split_host_and_port(authority)?;
-        let host = OriginHost::from_str(host_str)?;
-        Ok(Origin { host, port })
+        Ok(Origin {
+            scheme,
+            host,
+            port: url.port(),
+        })
     }
 }
 
@@ -144,35 +214,18 @@ impl TryFrom<&str> for Origin {
     }
 }
 
-fn split_host_and_port(s: &str) -> Result<(&str, Option<u16>), OriginParseError> {
-    // IPv6 literals are bracketed. Find the matching `]` first if present so
-    // we don't confuse `:` inside the address with the host/port separator.
-    if let Some(stripped) = s.strip_prefix('[') {
-        let end = stripped.find(']').ok_or_else(|| {
-            OriginParseError::InvalidHost(HostParseError::InvalidIp(s.to_string()))
-        })?;
-        let host = &s[..end + 2]; // include the brackets
-        let after = &s[end + 2..];
-        if after.is_empty() {
-            return Ok((host, None));
+fn map_url_parse_error(err: ParseError) -> OriginParseError {
+    match err {
+        ParseError::EmptyHost => OriginParseError::MissingHost,
+        ParseError::InvalidIpv4Address | ParseError::InvalidIpv6Address => {
+            OriginParseError::InvalidHost(HostParseError::InvalidIp(err.to_string()))
         }
-        let port_str = after
-            .strip_prefix(':')
-            .ok_or_else(|| OriginParseError::InvalidPort(after.to_string()))?;
-        let port = port_str
-            .parse::<u16>()
-            .map_err(|_| OriginParseError::InvalidPort(port_str.to_string()))?;
-        return Ok((host, Some(port)));
-    }
-
-    match s.rsplit_once(':') {
-        Some((host, port_str)) => {
-            let port = port_str
-                .parse::<u16>()
-                .map_err(|_| OriginParseError::InvalidPort(port_str.to_string()))?;
-            Ok((host, Some(port)))
+        ParseError::InvalidPort => OriginParseError::InvalidPort(err.to_string()),
+        ParseError::RelativeUrlWithoutBase => OriginParseError::InvalidScheme,
+        ParseError::IdnaError => {
+            OriginParseError::InvalidHost(HostParseError::InvalidDomain(err.to_string()))
         }
-        None => Ok((s, None)),
+        _ => OriginParseError::InvalidHost(HostParseError::InvalidDomain(err.to_string())),
     }
 }
 
@@ -301,10 +354,58 @@ mod tests {
     }
 
     #[test]
-    fn origin_rejects_non_https() {
+    fn origin_rejects_unknown_scheme() {
+        assert!(matches!(
+            "ftp://example.org".parse::<Origin>(),
+            Err(OriginParseError::InvalidScheme)
+        ));
+    }
+
+    #[test]
+    fn origin_rejects_http_for_non_localhost() {
         assert!(matches!(
             "http://example.org".parse::<Origin>(),
-            Err(OriginParseError::InvalidScheme)
+            Err(OriginParseError::InsecureHttpHost(_))
+        ));
+    }
+
+    #[test]
+    fn origin_accepts_http_localhost() {
+        let o: Origin = "http://localhost".parse().unwrap();
+        assert_eq!(o.scheme, Scheme::Http);
+        assert_eq!(o.host.as_str(), "localhost");
+        assert_eq!(o.port, None);
+        assert_eq!(o.to_string(), "http://localhost");
+    }
+
+    #[test]
+    fn origin_accepts_http_localhost_with_port() {
+        let o: Origin = "http://localhost:3000".parse().unwrap();
+        assert_eq!(o.scheme, Scheme::Http);
+        assert_eq!(o.host.as_str(), "localhost");
+        assert_eq!(o.port, Some(3000));
+        assert_eq!(o.to_string(), "http://localhost:3000");
+    }
+
+    #[test]
+    fn origin_accepts_https_localhost() {
+        let o: Origin = "https://localhost:8443".parse().unwrap();
+        assert_eq!(o.scheme, Scheme::Https);
+        assert_eq!(o.host.as_str(), "localhost");
+        assert_eq!(o.port, Some(8443));
+    }
+
+    #[test]
+    fn origin_rejects_http_loopback_ip() {
+        // Loopback IPs are not covered by this narrow allowance; only the
+        // literal "localhost" host qualifies for http://.
+        assert!(matches!(
+            "http://127.0.0.1".parse::<Origin>(),
+            Err(OriginParseError::InsecureHttpHost(_))
+        ));
+        assert!(matches!(
+            "http://[::1]".parse::<Origin>(),
+            Err(OriginParseError::InsecureHttpHost(_))
         ));
     }
 
@@ -351,8 +452,59 @@ mod tests {
 
     #[test]
     fn request_origin_try_from_string() {
+        // Default ports are stripped during parsing (WHATWG URL Standard), so
+        // `:443` on an https origin normalises to `port = None`.
         let r = RequestOrigin::try_from("https://example.org:443".to_string()).unwrap();
         assert_eq!(r.origin.host.as_str(), "example.org");
-        assert_eq!(r.origin.port, Some(443));
+        assert_eq!(r.origin.port, None);
+        assert_eq!(r.origin.to_string(), "https://example.org");
+    }
+
+    #[test]
+    fn origin_strips_default_http_port() {
+        let o: Origin = "http://localhost:80".parse().unwrap();
+        assert_eq!(o.port, None);
+        assert_eq!(o.to_string(), "http://localhost");
+    }
+
+    #[test]
+    fn origin_rejects_userinfo() {
+        assert!(matches!(
+            "https://user:pw@example.org".parse::<Origin>(),
+            Err(OriginParseError::UnexpectedUserinfo)
+        ));
+    }
+
+    #[test]
+    fn origin_normalises_uppercase_scheme_and_host() {
+        let o: Origin = "HTTPS://Example.ORG".parse().unwrap();
+        assert_eq!(o.scheme, Scheme::Https);
+        assert_eq!(o.host.as_str(), "example.org");
+        assert_eq!(o.to_string(), "https://example.org");
+    }
+
+    #[test]
+    fn origin_accepts_port_boundaries() {
+        let o: Origin = "https://example.org:1".parse().unwrap();
+        assert_eq!(o.port, Some(1));
+        let o: Origin = "https://example.org:65535".parse().unwrap();
+        assert_eq!(o.port, Some(65535));
+    }
+
+    #[test]
+    fn origin_accepts_port_zero() {
+        // Port 0 is syntactically valid per the WHATWG URL Standard, even
+        // though it is not a usable network port. Pin current behavior so a
+        // future change is visible.
+        let o: Origin = "https://example.org:0".parse().unwrap();
+        assert_eq!(o.port, Some(0));
+    }
+
+    #[test]
+    fn origin_new_defaults_to_https() {
+        let host: OriginHost = "example.org".parse().unwrap();
+        let origin = Origin::new(host, Some(8443));
+        assert_eq!(origin.scheme, Scheme::Https);
+        assert_eq!(origin.to_string(), "https://example.org:8443");
     }
 }

--- a/libwebauthn/src/ops/webauthn/idl/origin.rs
+++ b/libwebauthn/src/ops/webauthn/idl/origin.rs
@@ -53,9 +53,8 @@ impl FromStr for OriginHost {
             Ok(h) => Ok(OriginHost(h.to_string())),
             Err(err) => {
                 let msg = err.to_string();
-                if msg.contains("IPv4") || msg.contains("ipv4") {
-                    Err(HostParseError::InvalidIp(msg))
-                } else if msg.contains("IPv6") || msg.contains("ipv6") {
+                let lower = msg.to_lowercase();
+                if lower.contains("ipv4") || lower.contains("ipv6") {
                     Err(HostParseError::InvalidIp(msg))
                 } else {
                     Err(HostParseError::InvalidDomain(msg))
@@ -149,9 +148,9 @@ fn split_host_and_port(s: &str) -> Result<(&str, Option<u16>), OriginParseError>
     // IPv6 literals are bracketed. Find the matching `]` first if present so
     // we don't confuse `:` inside the address with the host/port separator.
     if let Some(stripped) = s.strip_prefix('[') {
-        let end = stripped
-            .find(']')
-            .ok_or_else(|| OriginParseError::InvalidHost(HostParseError::InvalidIp(s.to_string())))?;
+        let end = stripped.find(']').ok_or_else(|| {
+            OriginParseError::InvalidHost(HostParseError::InvalidIp(s.to_string()))
+        })?;
         let host = &s[..end + 2]; // include the brackets
         let after = &s[end + 2..];
         if after.is_empty() {

--- a/libwebauthn/src/ops/webauthn/make_credential.rs
+++ b/libwebauthn/src/ops/webauthn/make_credential.rs
@@ -19,7 +19,7 @@ use crate::{
             },
             Base64UrlString, FromIdlModel, JsonError, WebAuthnIDL,
         },
-        Operation, RelyingPartyId,
+        Operation, RelyingPartyId, RequestOrigin,
     },
     proto::{
         ctap1::{Ctap1RegisteredKey, Ctap1Version},
@@ -365,18 +365,19 @@ impl FromIdlModel<PublicKeyCredentialCreationOptionsJSON, MakeCredentialRequestP
     for MakeCredentialRequest
 {
     fn from_idl_model(
-        rpid: &RelyingPartyId,
+        request_origin: &RequestOrigin,
         inner: PublicKeyCredentialCreationOptionsJSON,
     ) -> Result<Self, MakeCredentialRequestParsingError> {
+        let effective_rp_id = request_origin.origin.host.as_str();
         let rp_id = RelyingPartyId::try_from(inner.rp.id.as_str()).map_err(|err| {
             MakeCredentialRequestParsingError::InvalidRelyingPartyId(err.to_string())
         })?;
         // TODO(#160): Add support for related origin per WebAuthn Level 3.
-        if rp_id.0 != rpid.0 {
+        if rp_id.0 != effective_rp_id {
             return Err(
                 MakeCredentialRequestParsingError::MismatchingRelyingPartyId(
                     rp_id.0,
-                    rpid.0.to_string(),
+                    effective_rp_id.to_string(),
                 ),
             );
         }
@@ -410,8 +411,8 @@ impl FromIdlModel<PublicKeyCredentialCreationOptionsJSON, MakeCredentialRequestP
 
         Ok(Self {
             challenge: inner.challenge.to_vec(),
-            origin: rpid.to_owned().into(),
-            top_origin: None,
+            origin: request_origin.origin.to_string(),
+            top_origin: request_origin.top_origin.as_ref().map(|o| o.to_string()),
             relying_party,
             user: inner.user.into(),
             resident_key,
@@ -641,8 +642,7 @@ impl DowngradableRequest<RegisterRequest> for MakeCredentialRequest {
 mod tests {
     use std::time::Duration;
 
-    use crate::ops::webauthn::MakeCredentialRequest;
-    use crate::ops::webauthn::RelyingPartyId;
+    use crate::ops::webauthn::{MakeCredentialRequest, RequestOrigin};
     use crate::proto::ctap2::Ctap2PublicKeyCredentialType;
 
     use super::*;
@@ -679,7 +679,7 @@ mod tests {
     fn request_base() -> MakeCredentialRequest {
         MakeCredentialRequest {
             challenge: base64_url::decode("Y3JlZGVudGlhbHMtZm9yLWxpbnV4L2xpYndlYmF1dGhu").unwrap(),
-            origin: "example.org".to_string(),
+            origin: "https://example.org".to_string(),
             top_origin: None,
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(b"userid", "mario.rossi", "Mario Rossi"),
@@ -707,10 +707,10 @@ mod tests {
     }
 
     fn test_request_from_json_required_field(field: &str) {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_rm(REQUEST_BASE_JSON, field);
 
-        let result = MakeCredentialRequest::from_json(&rpid, &req_json);
+        let result = MakeCredentialRequest::from_json(&request_origin, &req_json);
         assert!(matches!(
             result,
             Err(MakeCredentialRequestParsingError::EncodingError(_))
@@ -719,9 +719,9 @@ mod tests {
 
     #[test]
     fn test_request_from_json_base() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req: MakeCredentialRequest =
-            MakeCredentialRequest::from_json(&rpid, REQUEST_BASE_JSON).unwrap();
+            MakeCredentialRequest::from_json(&request_origin, REQUEST_BASE_JSON).unwrap();
         assert_eq!(req, request_base());
     }
 
@@ -748,11 +748,11 @@ mod tests {
     #[test]
     #[ignore] // FIXME(#134): Add validation for challenges
     fn test_request_from_json_challenge_empty() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json: String = json_field_rm(REQUEST_BASE_JSON, "challenge");
         let req_json = json_field_add(&req_json, "challenge", r#""""#);
 
-        let result = MakeCredentialRequest::from_json(&rpid, &req_json);
+        let result = MakeCredentialRequest::from_json(&request_origin, &req_json);
         assert!(matches!(
             result,
             Err(MakeCredentialRequestParsingError::EncodingError(_))
@@ -761,7 +761,7 @@ mod tests {
 
     #[test]
     fn test_request_from_json_prf_extension() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_add(
             REQUEST_BASE_JSON,
             "extensions",
@@ -769,7 +769,7 @@ mod tests {
         );
 
         let req: MakeCredentialRequest =
-            MakeCredentialRequest::from_json(&rpid, &req_json).unwrap();
+            MakeCredentialRequest::from_json(&request_origin, &req_json).unwrap();
         assert!(matches!(
             req.extensions,
             Some(MakeCredentialsRequestExtensions { prf: Some(_), .. })
@@ -778,14 +778,14 @@ mod tests {
 
     #[test]
     fn test_request_from_json_unknown_pub_key_cred_params() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_add(
             REQUEST_BASE_JSON,
             "pubKeyCredParams",
             r#"[{"type": "something", "alg": -12345}]"#,
         );
         let req: MakeCredentialRequest =
-            MakeCredentialRequest::from_json(&rpid, &req_json).unwrap();
+            MakeCredentialRequest::from_json(&request_origin, &req_json).unwrap();
         assert_eq!(
             req.algorithms,
             vec![Ctap2CredentialType {
@@ -797,11 +797,11 @@ mod tests {
 
     #[test]
     fn test_request_from_json_default_timeout() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_rm(REQUEST_BASE_JSON, "timeout");
 
         let req: MakeCredentialRequest =
-            MakeCredentialRequest::from_json(&rpid, &req_json).unwrap();
+            MakeCredentialRequest::from_json(&request_origin, &req_json).unwrap();
         assert_eq!(req.timeout, DEFAULT_TIMEOUT);
     }
 
@@ -809,11 +809,11 @@ mod tests {
     /// https://www.w3.org/TR/webauthn-3/#dom-authenticatorselectioncriteria-userverification
     #[test]
     fn test_request_from_json_default_user_verification_preferred() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_rm(REQUEST_BASE_JSON, "authenticatorSelection");
 
         let req: MakeCredentialRequest =
-            MakeCredentialRequest::from_json(&rpid, &req_json).unwrap();
+            MakeCredentialRequest::from_json(&request_origin, &req_json).unwrap();
         assert_eq!(
             req.user_verification,
             UserVerificationRequirement::Preferred
@@ -824,7 +824,7 @@ mod tests {
     /// it should default to "preferred".
     #[test]
     fn test_request_from_json_missing_user_verification_in_authenticator_selection() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         // Replace authenticatorSelection with one that has no userVerification field
         let mut req_json = json_field_rm(REQUEST_BASE_JSON, "authenticatorSelection");
         req_json = json_field_add(
@@ -834,7 +834,7 @@ mod tests {
         );
 
         let req: MakeCredentialRequest =
-            MakeCredentialRequest::from_json(&rpid, &req_json).unwrap();
+            MakeCredentialRequest::from_json(&request_origin, &req_json).unwrap();
         assert_eq!(
             req.user_verification,
             UserVerificationRequirement::Preferred
@@ -843,14 +843,14 @@ mod tests {
 
     #[test]
     fn test_request_from_json_invalid_rp_id() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_add(
             REQUEST_BASE_JSON,
             "rp",
             r#"{"id": "example.org.", "name": "example.org"}"#,
         );
 
-        let result = MakeCredentialRequest::from_json(&rpid, &req_json);
+        let result = MakeCredentialRequest::from_json(&request_origin, &req_json);
         assert!(matches!(
             result,
             Err(MakeCredentialRequestParsingError::InvalidRelyingPartyId(_))
@@ -859,14 +859,14 @@ mod tests {
 
     #[test]
     fn test_request_from_json_mismatching_rp_id() {
-        let rpid = RelyingPartyId::try_from("example.org").unwrap();
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_add(
             REQUEST_BASE_JSON,
             "rp",
             r#"{"id": "other.example.org", "name": "example.org"}"#,
         );
 
-        let result = MakeCredentialRequest::from_json(&rpid, &req_json);
+        let result = MakeCredentialRequest::from_json(&request_origin, &req_json);
         assert!(matches!(
             result,
             Err(MakeCredentialRequestParsingError::MismatchingRelyingPartyId(_, _))

--- a/libwebauthn/src/ops/webauthn/make_credential.rs
+++ b/libwebauthn/src/ops/webauthn/make_credential.rs
@@ -321,8 +321,9 @@ pub struct MakeCredentialRequest {
     pub challenge: Vec<u8>,
     /// The origin of the request.
     pub origin: String,
-    /// Whether the request is cross-origin (optional per WebAuthn spec).
-    pub cross_origin: Option<bool>,
+    /// The top-level origin if the request was made from a cross-origin
+    /// nested browsing context. None for same-origin requests.
+    pub top_origin: Option<String>,
     /// rpEntity
     pub relying_party: Ctap2PublicKeyCredentialRpEntity,
     /// userEntity
@@ -345,8 +346,7 @@ impl MakeCredentialRequest {
             operation: Operation::MakeCredential,
             challenge: self.challenge.clone(),
             origin: self.origin.clone(),
-            cross_origin: self.cross_origin,
-            top_origin: None,
+            top_origin: self.top_origin.clone(),
         }
     }
 
@@ -411,7 +411,7 @@ impl FromIdlModel<PublicKeyCredentialCreationOptionsJSON, MakeCredentialRequestP
         Ok(Self {
             challenge: inner.challenge.to_vec(),
             origin: rpid.to_owned().into(),
-            cross_origin: None,
+            top_origin: None,
             relying_party,
             user: inner.user.into(),
             resident_key,
@@ -554,7 +554,7 @@ impl MakeCredentialRequest {
         Self {
             challenge: Vec::new(),
             origin: "example.org".to_owned(),
-            cross_origin: Some(false),
+            top_origin: None,
             relying_party: Ctap2PublicKeyCredentialRpEntity::dummy(),
             user: Ctap2PublicKeyCredentialUserEntity::dummy(),
             algorithms: vec![Ctap2CredentialType::default()],
@@ -680,7 +680,7 @@ mod tests {
         MakeCredentialRequest {
             challenge: base64_url::decode("Y3JlZGVudGlhbHMtZm9yLWxpbnV4L2xpYndlYmF1dGhu").unwrap(),
             origin: "example.org".to_string(),
-            cross_origin: None,
+            top_origin: None,
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(b"userid", "mario.rossi", "Mario Rossi"),
             resident_key: Some(ResidentKeyRequirement::Discouraged),
@@ -918,7 +918,7 @@ mod tests {
         MakeCredentialRequest {
             challenge: b"DEADCODE_challenge".to_vec(),
             origin: "example.org".to_string(),
-            cross_origin: None,
+            top_origin: None,
             relying_party: Ctap2PublicKeyCredentialRpEntity::new("example.org", "example.org"),
             user: Ctap2PublicKeyCredentialUserEntity::new(b"userid", "mario.rossi", "Mario Rossi"),
             resident_key: Some(ResidentKeyRequirement::Discouraged),

--- a/libwebauthn/src/ops/webauthn/mod.rs
+++ b/libwebauthn/src/ops/webauthn/mod.rs
@@ -15,7 +15,7 @@ pub use get_assertion::{
     HMACGetSecretOutput, PRFValue, PrfInput,
 };
 pub use idl::{
-    origin::{HostParseError, Origin, OriginHost, OriginParseError, RequestOrigin},
+    origin::{HostParseError, Origin, OriginHost, OriginParseError, RequestOrigin, Scheme},
     rpid::RelyingPartyId,
     AuthenticationExtensionsClientOutputsJSON, AuthenticationResponseJSON,
     AuthenticatorAssertionResponseJSON, AuthenticatorAttestationResponseJSON, Base64UrlString,

--- a/libwebauthn/src/ops/webauthn/mod.rs
+++ b/libwebauthn/src/ops/webauthn/mod.rs
@@ -15,7 +15,9 @@ pub use get_assertion::{
     HMACGetSecretOutput, PRFValue, PrfInput,
 };
 pub use idl::{
-    rpid::RelyingPartyId, AuthenticationExtensionsClientOutputsJSON, AuthenticationResponseJSON,
+    origin::{HostParseError, Origin, OriginHost, OriginParseError, RequestOrigin},
+    rpid::RelyingPartyId,
+    AuthenticationExtensionsClientOutputsJSON, AuthenticationResponseJSON,
     AuthenticatorAssertionResponseJSON, AuthenticatorAttestationResponseJSON, Base64UrlString,
     JsonFormat, RegistrationResponseJSON, ResponseSerializationError, WebAuthnIDL,
     WebAuthnIDLResponse,

--- a/libwebauthn/src/proto/ctap2/model/get_assertion.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_assertion.rs
@@ -612,7 +612,7 @@ mod tests {
             relying_party_id: "example.com".to_string(),
             challenge: vec![0u8; 32],
             origin: "https://example.com".to_string(),
-            cross_origin: None,
+            top_origin: None,
             allow,
             extensions: None,
             user_verification: Default::default(),

--- a/libwebauthn/src/webauthn/pin_uv_auth_token.rs
+++ b/libwebauthn/src/webauthn/pin_uv_auth_token.rs
@@ -583,7 +583,7 @@ mod test {
                 extensions,
                 user_verification: UserVerificationRequirement::Preferred,
                 timeout: TIMEOUT,
-                cross_origin: None,
+                top_origin: None,
             },
             info,
         )


### PR DESCRIPTION
## Motivation

Closes #185.

`WebAuthnIDL::from_json` currently takes a `&RelyingPartyId`, which forces callers (e.g. credentialsd) to override `request.origin` and `request.cross_origin` after parsing because the bare host is not a valid origin string and we have no place to record the top-level origin. This replaces that parameter with a `RequestOrigin` that carries the actual origin context, so the parsed request comes out correct without a post-parse fixup.

## What changes

- New `Origin` and `RequestOrigin` types in `libwebauthn::ops::webauthn`. `Origin` is a struct with `host: OriginHost` and `port: Option<u16>`; `RequestOrigin` wraps it with an optional `top_origin`. Convenience constructors: `RequestOrigin::new(origin)`, `RequestOrigin::new_cross_origin(origin, top_origin)`, `RequestOrigin::try_from(&str | String)` for one-shot parsing of `"https://host[:port]"`.
- Host validation goes through `url::Host` so we follow the WHATWG URL Standard host parser (domain / IPv4 / bracketed IPv6). Errors are wrapped into a local `HostParseError` / `OriginParseError` so the `url` crate's error type does not leak into the public API.
- `WebAuthnIDL::from_json` and `FromIdlModel::from_idl_model` now take `&RequestOrigin`. The parsed `request.origin` is the full URL string (`"https://example.org"`, no longer the bare host), and `request.top_origin: Option<String>` replaces the old `cross_origin: Option<bool>`.
- `ClientData` drops `cross_origin: Option<bool>` and derives `crossOrigin` in the JSON from `top_origin.is_some()`. `topOrigin` is now emitted when present.
- Bumps libwebauthn to `0.4.0` since the public `from_json` signature and the request struct fields are breaking changes.

## Intentional non-changes

- `Origin` is a plain struct, not an enum. We only support `https`. If we need to support a second scheme later it can become an enum without breaking call-site field access.
- `rp.id` validation against the origin is still strict equality. The spec actually wants a registrable-suffix check (WebAuthn L3 §5.1.3 / §5.1.7); that is tracked separately in #187 and can build on the PSL helpers from #173.

## Test plan

- [x] `cargo build -p libwebauthn` and `cargo build -p libwebauthn --features virt`
- [x] `cargo build --workspace --all-targets --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (149 tests, 14 new origin parser tests)
- [x] `cargo publish --dry-run -p libwebauthn` (no working-tree hacks)