### PR TITLE
fix(webauthn): strip transports from CTAP2 PublicKeyCredentialDescriptor

### DIFF
--- a/libwebauthn/examples/webauthn_hid.rs
+++ b/libwebauthn/examples/webauthn_hid.rs
@@ -16,7 +16,7 @@ use libwebauthn::ops::webauthn::{
 use libwebauthn::pin::{PinNotSetReason, PinRequestReason};
 use libwebauthn::proto::ctap2::{
     Ctap2CredentialType, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
-    Ctap2PublicKeyCredentialUserEntity,
+    Ctap2PublicKeyCredentialUserEntity, Ctap2Transport,
 };
 use libwebauthn::transport::hid::list_devices;
 use libwebauthn::transport::{Channel as _, Device};
@@ -156,6 +156,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
 
         let credential: Ctap2PublicKeyCredentialDescriptor =
             (&response.authenticator_data).try_into().unwrap();
+        let credential = Ctap2PublicKeyCredentialDescriptor {
+            transports: Some(vec![Ctap2Transport::Usb]),
+            ..credential
+        };
         let get_assertion = GetAssertionRequest {
             relying_party_id: "example.org".to_owned(),
             challenge: Vec::from(challenge),

--- a/libwebauthn/examples/webauthn_json_hid.rs
+++ b/libwebauthn/examples/webauthn_json_hid.rs
@@ -12,6 +12,7 @@ use libwebauthn::ops::webauthn::{
     WebAuthnIDL as _, WebAuthnIDLResponse as _,
 };
 use libwebauthn::pin::PinRequestReason;
+use libwebauthn::proto::ctap2::Ctap2PublicKeyCredentialDescriptor;
 use libwebauthn::transport::hid::list_devices;
 use libwebauthn::transport::{Channel as _, Device};
 use libwebauthn::webauthn::{Error as WebAuthnError, WebAuthn};
@@ -152,16 +153,24 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
 
-        let request_json = r#"
-                {
+        let cred: Ctap2PublicKeyCredentialDescriptor =
+            (&response.authenticator_data).try_into().unwrap();
+        let cred_id_b64 = base64_url::encode(cred.id.as_ref());
+        let request_json = format!(
+            r#"
+                {{
                     "challenge": "Y3JlZGVudGlhbHMtZm9yLWxpbnV4L2xpYndlYmF1dGhu",
                     "timeout": 30000,
                     "rpId": "example.org",
-                    "userVerification": "discouraged"
-                }
-                "#;
+                    "userVerification": "discouraged",
+                    "allowCredentials": [
+                        {{"id": "{cred_id_b64}", "type": "public-key", "transports": ["usb"]}}
+                    ]
+                }}
+                "#
+        );
         let get_assertion: GetAssertionRequest =
-            GetAssertionRequest::from_json(&request_origin, &psl, request_json)
+            GetAssertionRequest::from_json(&request_origin, &psl, &request_json)
                 .expect("Failed to parse request JSON");
         println!("WebAuthn GetAssertion request: {:?}", get_assertion);
 

--- a/libwebauthn/src/proto/ctap2/model.rs
+++ b/libwebauthn/src/proto/ctap2/model.rs
@@ -164,7 +164,11 @@ pub struct Ctap2PublicKeyCredentialDescriptor {
     pub id: ByteBuf,
     pub r#type: Ctap2PublicKeyCredentialType,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // CTAP2 PublicKeyCredentialDescriptor only carries `id` and `type` on the wire.
+    // Strict authenticators reject extra fields with CTAP2_ERR_INVALID_CBOR (0x12).
+    // We keep `transports` in memory for U2F downgrade and accept it on deserialize
+    // (some authenticators include it in responses), but never serialize it.
+    #[serde(skip_serializing, default)]
     pub transports: Option<Vec<Ctap2Transport>>,
 }
 
@@ -245,7 +249,10 @@ mod tests {
     use crate::proto::ctap2::cbor;
     use crate::proto::ctap2::Ctap2PublicKeyCredentialDescriptor;
 
-    use super::{Ctap2COSEAlgorithmIdentifier, Ctap2CredentialType, Ctap2PublicKeyCredentialType};
+    use super::{
+        Ctap2COSEAlgorithmIdentifier, Ctap2CredentialType, Ctap2PublicKeyCredentialType,
+        Ctap2Transport,
+    };
     use hex;
     use serde_bytes::ByteBuf;
     use serde_cbor_2 as serde_cbor;
@@ -275,6 +282,36 @@ mod tests {
         // Known good, verified by hand with cbor.me playground
         let expected = hex::decode("a2626964414264747970656a7075626c69632d6b6579").unwrap();
         assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    /// CTAP2 PublicKeyCredentialDescriptor is `{id, type}` only; `transports` is a
+    /// WebAuthn-level field that strict authenticators reject as InvalidCbor (#191).
+    pub fn credential_descriptor_serialization_strips_transports() {
+        let credential_descriptor = Ctap2PublicKeyCredentialDescriptor {
+            id: ByteBuf::from(vec![0x42]),
+            r#type: Ctap2PublicKeyCredentialType::PublicKey,
+            transports: Some(vec![Ctap2Transport::Usb]),
+        };
+        let serialized = cbor::to_vec(&credential_descriptor).unwrap();
+        let expected = hex::decode("a2626964414264747970656a7075626c69632d6b6579").unwrap();
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    /// Some authenticators include `transports` in CTAP2 responses even though the spec
+    /// doesn't list it; we must remain tolerant when deserializing.
+    pub fn credential_descriptor_deserialization_accepts_transports() {
+        // python $ cbor2.dumps({"id": bytes([0x42]), "type": "public-key", "transports": ["usb"]}).hex()
+        let serialized = hex::decode(
+            "a3626964414264747970656a7075626c69632d6b65796a7472616e73706f7274738163757362",
+        )
+        .unwrap();
+        let descriptor: Ctap2PublicKeyCredentialDescriptor =
+            serde_cbor::from_slice(&serialized).unwrap();
+        assert_eq!(descriptor.id, ByteBuf::from(vec![0x42]));
+        assert_eq!(descriptor.r#type, Ctap2PublicKeyCredentialType::PublicKey);
+        assert_eq!(descriptor.transports, Some(vec![Ctap2Transport::Usb]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Strip the WebAuthn `transports` field from the CTAP2 `PublicKeyCredentialDescriptor`
that we send to authenticators. Fixes #191.

## Why

`transports` is a WebAuthn-level hint for the *client* about which transport to
try ([WebAuthn L3 §5.8.3](https://www.w3.org/TR/webauthn-3/#dictionary-credential-descriptor),
[§5.8.4](https://www.w3.org/TR/webauthn-3/#enum-transport)). The CTAP spec
hyperlinks the WebAuthn dictionary, so the field is technically permitted on the
wire, but every reference platform omits it and at least one shipping
authenticator firmware breaks when it's present.

### What other clients do

**Chromium** strips the field and the source has an explicit comment about it:

```cpp
// device/fido/public/public_key_credential_descriptor.cc, AsCBOR()
cbor_descriptor_map[cbor::Value(kCredentialIdKey)]   = cbor::Value(desc.id);
cbor_descriptor_map[cbor::Value(kCredentialTypeKey)] =
    cbor::Value(CredentialTypeToString(desc.credential_type));
// Transports are omitted from CBOR serialization. They aren't useful for
// security keys to process. Some existing devices even refuse to parse them
// (see https://crbug.com/1270757).
```

Source: [public_key_credential_descriptor.cc](https://chromium.googlesource.com/chromium/src/+/499f1e3bbe2eb615af5f484fc096b20432007622/device/fido/public/public_key_credential_descriptor.cc#84) (HEAD as of 2026-05-09). Reached from both
[ctap_get_assertion_request.cc](https://chromium.googlesource.com/chromium/src/+/499f1e3bbe2eb615af5f484fc096b20432007622/device/fido/ctap_get_assertion_request.cc#288)
(allowList) and
[ctap_make_credential_request.cc](https://chromium.googlesource.com/chromium/src/+/499f1e3bbe2eb615af5f484fc096b20432007622/device/fido/ctap_make_credential_request.cc#310)
(excludeList).

**libfido2** physically can't include it. The descriptor encoder is hard-coded
as a definite-size-2 map:

```c
// src/cbor.c, cbor_encode_pubkey()
if ((cbor_key = cbor_new_definite_map(2)) == NULL ||
    cbor_add_bytestring(cbor_key, "id", pubkey->ptr, pubkey->len) < 0 ||
    cbor_add_string(cbor_key, "type", "public-key") < 0) {
```

Source: [src/cbor.c](https://github.com/Yubico/libfido2/blob/1.17.0/src/cbor.c#L522-L536) (libfido2 1.17.0). Reached from
[fido_dev_get_assert_tx](https://github.com/Yubico/libfido2/blob/1.17.0/src/assert.c#L112-L120)
and [fido_dev_make_cred_tx](https://github.com/Yubico/libfido2/blob/1.17.0/src/cred.c#L74-L80).

### What goes wrong on Solo 2 specifically

Issue #191's bug log is from a Solo 2 firmware r964 (release `2.964.0`); I
also reproduced on a Solo 2 r256 (firmware family `1.0.x`). Both ship
[`fido-authenticator = 0.1.x`](https://crates.io/crates/fido-authenticator/0.1.1)
which pulls in
[`cbor-smol = 0.4.0`](https://github.com/trussed-dev/cbor-smol/blob/0.4.0/src/de.rs).
That cbor-smol has a bug in `deserialize_ignored_any` that breaks when serde-derive
tries to skip an unknown map key whose value is non-empty:

```rust
// cbor-smol 0.4.0 src/de.rs
fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>
where V: Visitor<'de>,
{
    // Ignore extra fields/options
    visitor.visit_none()  // does not advance the input cursor
}
```

The function returns `visit_none()` without consuming the value bytes, so the
next `next_key_seed` call reads the descriptor's leftover `transports` value as
the next map key. The misread fails with `DeserializeBadMajor`, which
[`ctap-types`](https://github.com/trussed-dev/ctap-types/blob/v0.1.2/src/ctap2.rs)
then maps to `CTAP2_ERR_INVALID_CBOR (0x12)` and that is what the device puts on
the wire. Reproduced in isolation:

```
[1] outer + descriptor (no transports)         -> Ok(...)
[2] outer + descriptor (transports as 3rd key) -> Err(DeserializeBadMajor)
```

### How libwebauthn was hitting this

In 0.2.x the only path that built a `Ctap2PublicKeyCredentialDescriptor` was
`From<&AttestedCredentialData>` (`fido.rs:73`), which hard-coded
`transports: None`. The 0.3.0 IDL/JSON parser at `idl/get.rs` and `idl/create.rs`
is the first code path that propagates a JSON-supplied `transports` into the
CTAP type, and the existing `#[serde(skip_serializing_if = "Option::is_none")]`
then emits it on the wire whenever the JSON included it. Firefox does include
it, which is how the bug surfaced.

## Changes

- `proto/ctap2/model.rs`: change the descriptor's `transports` field to
  `#[serde(skip_serializing, default)]`. Never emitted on the wire; still
  accepted on deserialize, since some authenticators include it in responses
  even though CTAP doesn't require it. The field stays in the in-memory type
  for U2F downgrade (`make_credential.rs:620`).
- `proto/ctap2/model.rs` tests: keep the existing happy-path
  `credential_descriptor_serialization`; add
  `credential_descriptor_serialization_strips_transports` (proves a populated
  `transports` is dropped on the wire) and
  `credential_descriptor_deserialization_accepts_transports` (proves we still
  parse it from a response).
- `examples/webauthn_hid.rs` and `examples/webauthn_json_hid.rs`: the example
  GetAssertion now includes the freshly-made credential in `allowList` with
  `transports = [Usb]` / `"transports": ["usb"]`. Without the fix these
  reproduce #191 on a Solo 2; with the fix they succeed.

## Upstream status

The bug is in `cbor-smol = 0.4.x`'s `deserialize_ignored_any`: it calls
`visit_none()` without advancing the input cursor when serde-derive skips an
unknown map key, so the next `next_key_seed` reads the leftover value bytes
as if they were the next key and fails. Already fixed upstream in
[`0326d75f`](https://github.com/trussed-dev/cbor-smol/commit/0326d75fee8891a2e41b1db64e3e739d8c761a16)
(Oct 2024, released as cbor-smol 0.4.1 / 0.5.0) and adopted by
[`fido-authenticator 0.2.0`](https://crates.io/crates/fido-authenticator/0.2.0).

Reach by device:

| Device | Firmware (latest) | `cbor-smol` | Affected |
|---|---|---|---|
| SoloKeys Solo 2 r256 | `1.0.9` (Jan 2022) | 0.4.0 | yes |
| SoloKeys Solo 2 r964 | `2.964.0` (Aug 2022) | 0.4.0 | yes |
| Nitrokey 3 | [`v1.8.3`](https://github.com/Nitrokey/nitrokey-3-firmware/releases/tag/v1.8.3) (May 2025) | 0.5.0 | no |
| Yubikey / libfido2-style stacks | n/a (permissive parser) | n/a | no |

The SoloKeys project has been dormant since `2.964.0`; no firmware update
appears to be forthcoming. Nitrokey 3 ships
[`Nitrokey/fido-authenticator@v0.1.1-nitrokey.27`](https://github.com/Nitrokey/fido-authenticator/blob/v0.1.1-nitrokey.27/Cargo.toml),
which forked fido-authenticator's deps and bumped to `cbor-smol = "0.5"`,
transitively absorbing the fix.

The libwebauthn workaround in this PR is therefore the only fix that will
ever reach Solo 2 owners, and harmless on Nitrokey 3 / Yubikey (their
parsers already discarded the field). No code change is being requested
against `cbor-smol`, `fido-authenticator`, or `ctap-types`; all are correct
at HEAD.

Note: the parser bug affects every CTAP CBOR map the device parses where an
unknown key's value is more than zero bytes, not just `transports`. Other
clients sending other unknown keys would hit the same desync on a Solo 2.

## Test plan

- [x] `cargo test --lib` 136 existing tests pass; 2 new tests added
- [x] Reproduced #191 on a Solo 2 r256 with the example patch and the fix
      reverted (`InvalidCbor` -> preflight filters all credentials -> `NoCredentials`)
- [x] Verified the fix on the same Solo 2 r256 examples succeed
- [x] No regression on a Yubikey Security Key NFC A (was tolerant before, still works)