### PR TITLE
fix(ctap1): emit Le on U2F APDUs to support case 4

### DIFF
--- a/libwebauthn/src/proto/ctap1/apdu/request.rs
+++ b/libwebauthn/src/proto/ctap1/apdu/request.rs
@@ -106,6 +106,14 @@ impl ApduRequest {
             raw.write_u24::<BigEndian>(0)?;
         }
 
+        // Per ISO 7816-4 and FIDO U2F Raw Message Formats §3, §4: when a
+        // response is expected, append a 2-byte extended-length Le.
+        // Le=0x0000 is the wildcard meaning "up to 65536 bytes".
+        if let Some(le) = self.response_max_length {
+            let le_field = if le >= 0x1_0000 { 0u16 } else { le as u16 };
+            raw.write_u16::<BigEndian>(le_field)?;
+        }
+
         Ok(raw)
     }
 }
@@ -209,5 +217,70 @@ mod tests {
             &[0x00, 0x01, 0x02, 0x03, 0x00, 0x02, 0x00],
         );
         assert_eq!(&serialized[7..519], data.as_slice());
+    }
+
+    #[test]
+    fn apdu_raw_long_with_data_and_le() {
+        // Case 4 Extended APDU: header + Lc(3 BE) + data + Le(2 BE).
+        let data: Vec<u8> = vec![0xAA, 0xBB, 0xCC];
+        let apdu = ApduRequest::new(0x01, 0x02, 0x03, Some(&data), Some(0x100));
+        assert_eq!(
+            apdu.raw_long().unwrap(),
+            [
+                0x00, 0x01, 0x02, 0x03, // CLA, INS, P1, P2
+                0x00, 0x00, 0x03, // Lc = 3 (extended)
+                0xAA, 0xBB, 0xCC, // payload
+                0x01, 0x00, // Le = 256 (big-endian)
+            ],
+        );
+    }
+
+    #[test]
+    fn apdu_raw_long_no_data_with_le() {
+        // Case 2 Extended APDU: header + Lc=0 (3 BE) + Le(2 BE).
+        let apdu = ApduRequest::new(0x01, 0x02, 0x03, None, Some(0x100));
+        assert_eq!(
+            apdu.raw_long().unwrap(),
+            [
+                0x00, 0x01, 0x02, 0x03, // CLA, INS, P1, P2
+                0x00, 0x00, 0x00, // Lc = 0 (extended)
+                0x01, 0x00, // Le = 256 (big-endian)
+            ],
+        );
+    }
+
+    #[test]
+    fn apdu_raw_long_with_data_and_le_wildcard() {
+        // Le >= 65536 encodes as 0x0000 wildcard per ISO 7816-4.
+        let data: Vec<u8> = vec![0xAA];
+        let apdu = ApduRequest::new(0x01, 0x02, 0x03, Some(&data), Some(0x1_0000));
+        let serialized = apdu.raw_long().unwrap();
+        let trailing = &serialized[serialized.len() - 2..];
+        assert_eq!(trailing, &[0x00, 0x00], "Le wildcard for max length");
+    }
+
+    #[test]
+    fn apdu_raw_long_register_request_is_case_4() {
+        // Mirrors the encoding produced by `From<&Ctap1RegisterRequest> for ApduRequest`.
+        let mut payload = vec![0x11u8; 32]; // challenge
+        payload.extend(vec![0x22u8; 32]); // app id hash
+        let apdu = ApduRequest::new(
+            0x01, // U2F_REGISTER
+            0x03, // CONTROL_BYTE_ENFORCE_UP_AND_SIGN
+            0x00,
+            Some(&payload),
+            Some(0x100),
+        );
+        let serialized = apdu.raw_long().unwrap();
+        // Header (4) + extended Lc (3) + payload (64) + extended Le (2)
+        assert_eq!(serialized.len(), 4 + 3 + 64 + 2);
+        // Must terminate with the 2-byte Le; otherwise it is Case 3 and
+        // strict authenticators reject it.
+        let trailing = &serialized[serialized.len() - 2..];
+        assert_eq!(
+            trailing,
+            &[0x01, 0x00],
+            "REGISTER must be Case 4 with Le=256 (extended)",
+        );
     }
 }

--- a/libwebauthn/src/transport/nfc/commands.rs
+++ b/libwebauthn/src/transport/nfc/commands.rs
@@ -83,13 +83,20 @@ impl<'a> From<CtapMsgCommand<'a>> for Command<'a> {
 
 impl<'a> From<&'a ApduRequest> for Command<'a> {
     fn from(cmd: &'a ApduRequest) -> Self {
-        Self::new_with_payload(
-            0, // CLA
-            cmd.ins,
-            cmd.p1,
-            cmd.p2,
-            cmd.data.as_deref().unwrap_or(&[]),
-        )
+        // U2F REGISTER and AUTHENTICATE are Case 4 APDUs per FIDO U2F Raw
+        // Message Formats §3 / §4 and FIDO U2F NFC §3.1: the encoder must
+        // propagate `response_max_length` as Le so the authenticator knows
+        // a response payload is expected. Strict implementations reject
+        // requests missing Le.
+        let payload = cmd.data.as_deref().unwrap_or(&[]);
+        match cmd.response_max_length {
+            Some(le) => {
+                // Short-form Le: APDU_SHORT_LE (256) is mapped to a single
+                // byte 0x00 by apdu-core (`l as u8`).
+                Self::new_with_payload_le(CLA_DEFAULT, cmd.ins, cmd.p1, cmd.p2, le as u16, payload)
+            }
+            None => Self::new_with_payload(CLA_DEFAULT, cmd.ins, cmd.p1, cmd.p2, payload),
+        }
     }
 }
 
@@ -98,4 +105,33 @@ impl_into_vec!(CtapMsgCommand<'a>);
 /// Constructs a `GET MSG` command.
 pub fn command_ctap_msg(has_more: bool, payload: &[u8]) -> CtapMsgCommand<'_> {
     CtapMsgCommand::new(has_more, payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apdu_request_with_le_encodes_as_case_4_short() {
+        // U2F REGISTER-style request: 64 byte payload, Le = 256.
+        // Short form encodes Le as a single 0x00 byte (since 256 as u8 = 0).
+        let payload = vec![0xAAu8; 64];
+        let request = ApduRequest::new(0x01, 0x03, 0x00, Some(&payload), Some(0x100));
+        let bytes: Vec<u8> = Command::from(&request).into();
+        assert_eq!(bytes[0..5], [0x00, 0x01, 0x03, 0x00, 0x40]); // header + Lc=64
+        assert_eq!(&bytes[5..69], payload.as_slice());
+        assert_eq!(bytes[69], 0x00, "Le must be present (0x00 = 256)");
+        assert_eq!(bytes.len(), 70);
+    }
+
+    #[test]
+    fn apdu_request_without_le_encodes_as_case_3() {
+        // Genuine Case 3: no Le.
+        let payload = vec![0xAAu8; 64];
+        let request = ApduRequest::new(0x01, 0x03, 0x00, Some(&payload), None);
+        let bytes: Vec<u8> = Command::from(&request).into();
+        assert_eq!(bytes[0..5], [0x00, 0x01, 0x03, 0x00, 0x40]); // header + Lc=64
+        assert_eq!(&bytes[5..69], payload.as_slice());
+        assert_eq!(bytes.len(), 69, "no trailing Le");
+    }
 }


### PR DESCRIPTION
U2F REGISTER and AUTHENTICATE produce a response payload, so per FIDO U2F Raw Message Formats v1.2 section 3.1 the request APDU must include `Le` (omitting `Le` is reserved for instructions not expected to yield response bytes). libwebauthn was setting `response_max_length` on the `ApduRequest` but both encoders silently dropped it:

- `ApduRequest::raw_long` stopped after the `Lc + data` field. With `response_max_length = Some(0x100)` the byte stream came out as a Case 3 extended APDU (no `Le`).
- The NFC `From<&ApduRequest> for Command` used `Command::new_with_payload`, which does not carry `Le` at all.

Strict authenticators reject Case 3 register/authenticate. The in-tree virtual `fido-authenticator` is lenient about it, so CI never caught the gap.

## Changes
- `ApduRequest::raw_long` now appends a 2-byte big-endian `Le` when `response_max_length` is `Some(_)`, matching the extended-length encoding `Le1 Le2` from FIDO U2F Raw Message Formats v1.2 section 3.1.3. Values `>= 65536` collapse to `0x0000` (the spec's wildcard for `Ne = 65536`). This is the path used by HID, BLE, and caBLE, all of which mandate extended-length encoding (FIDO U2F HID v1.2 section 2.4; FIDO U2F BT v1.2 sections 5.1 and 5.2).
- NFC `From<&ApduRequest> for Command` switches to `Command::new_with_payload_le`, so `response_max_length` is propagated through `apdu-core`. With `longer_payloads` disabled (the default in this crate), `apdu-core` writes `Le` as a single byte; for the typical request with `response_max_length = 256` this yields `Le = 0x00`, which is short-form Case 4 and valid under FIDO U2F NFC v1.2 section 3 ("either short or extended length APDU encoding is allowed").
- Unit tests cover the Case 3 / Case 4 encoding for both `raw_long` and the NFC encoder, including the wildcard `Le = 0x0000`.

## Spec references
- FIDO U2F Raw Message Formats v1.2, sections 3 (framing), 4 (REGISTER), 5 (AUTHENTICATE): https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html
- FIDO U2F HID Protocol v1.2, section 2.4: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-hid-protocol-v1.2-ps-20170411.html
- FIDO U2F NFC Protocol v1.2, section 3: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-nfc-protocol-v1.2-ps-20170411.html
- FIDO U2F BLE Protocol v1.2, sections 5.1, 5.2: https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-bt-protocol-v1.2-ps-20170411.html