### PR TITLE
fix(cable): propagate post-handshake errors from protocol::connection

### DIFF
--- a/libwebauthn/src/transport/cable/known_devices.rs
+++ b/libwebauthn/src/transport/cable/known_devices.rs
@@ -98,24 +98,27 @@ impl From<&CableLinkingInfo> for CableKnownDeviceId {
 }
 
 impl CableKnownDeviceInfo {
-    pub(crate) fn new(tunnel_domain: &str, linking_info: &CableLinkingInfo) -> Result<Self, Error> {
+    pub(crate) fn new(
+        tunnel_domain: &str,
+        linking_info: &CableLinkingInfo,
+    ) -> Result<Self, TransportError> {
         let info = Self {
             contact_id: linking_info.contact_id.to_vec(),
             link_id: linking_info
                 .link_id
                 .clone()
                 .try_into()
-                .map_err(|_| Error::Transport(TransportError::InvalidFraming))?,
+                .map_err(|_| TransportError::InvalidFraming)?,
             link_secret: linking_info
                 .link_secret
                 .clone()
                 .try_into()
-                .map_err(|_| Error::Transport(TransportError::InvalidFraming))?,
+                .map_err(|_| TransportError::InvalidFraming)?,
             public_key: linking_info
                 .authenticator_public_key
                 .clone()
                 .try_into()
-                .map_err(|_| Error::Transport(TransportError::InvalidFraming))?,
+                .map_err(|_| TransportError::InvalidFraming)?,
             name: linking_info.authenticator_name.clone(),
             tunnel_domain: tunnel_domain.to_string(),
         };

--- a/libwebauthn/src/transport/cable/known_devices.rs
+++ b/libwebauthn/src/transport/cable/known_devices.rs
@@ -223,10 +223,17 @@ impl<'d> Device<'d, Cable, CableChannel> for CableKnownDevice {
                 cbor_rx_send,
             );
 
-            protocol::connection(tunnel_input).await;
-            ux_sender
-                .set_connection_state(ConnectionState::Terminated)
-                .await;
+            match protocol::connection(tunnel_input).await {
+                Ok(()) => {
+                    ux_sender
+                        .set_connection_state(ConnectionState::Terminated)
+                        .await;
+                }
+                Err(e) => {
+                    // send_error already transitions to Terminated.
+                    ux_sender.send_error(e).await;
+                }
+            }
         });
 
         Ok(CableChannel {

--- a/libwebauthn/src/transport/cable/protocol.rs
+++ b/libwebauthn/src/transport/cable/protocol.rs
@@ -117,6 +117,14 @@ enum CableTunnelMessageType {
     Update = 2,
 }
 
+/// Result of processing a single inbound tunnel frame.
+enum RecvOutcome {
+    /// Frame handled, keep the loop running.
+    Continue,
+    /// Peer sent a `Shutdown` control message; close the channel cleanly.
+    PeerShutdown,
+}
+
 #[derive(Clone)]
 pub(crate) enum CableTunnelConnectionType {
     QrCode {
@@ -268,36 +276,36 @@ pub(crate) async fn do_handshake(
     })
 }
 
-pub(crate) async fn connection(mut input: TunnelConnectionInput) {
-    // Fetch the initial message
+/// Returns `Ok(())` on a clean close and `Err(_)` on any fault that leaves
+/// the encrypted channel unusable; callers surface `Err(_)` via `send_error`.
+pub(crate) async fn connection(mut input: TunnelConnectionInput) -> Result<(), TransportError> {
     let get_info_response_serialized: Vec<u8> = match input.data_channel.recv().await {
         Ok(Some(message)) => match connection_recv_initial(message, &mut input.noise_state).await {
             Ok(initial) => initial,
             Err(e) => {
                 error!(?e, "Failed to process initial message");
-                return;
+                return Err(e);
             }
         },
         Ok(None) => {
             error!("Connection closed before initial message was received");
-            return;
+            return Err(TransportError::ConnectionLost);
         }
         Err(e) => {
             error!(?e, "Failed to read initial message");
-            return;
+            return Err(e);
         }
     };
     debug!(?get_info_response_serialized, "Received initial message");
 
     loop {
-        // Wait for a message on the data channel, or a request to send on cbor_tx_recv
         tokio::select! {
             result = input.data_channel.recv() => {
                 match result {
                     Ok(Some(message)) => {
                         debug!("Received data channel message");
                         trace!(?message);
-                        let _ = connection_recv(
+                        match connection_recv(
                             &input.connection_type,
                             &input.tunnel_domain,
                             &input.known_device_store,
@@ -305,15 +313,23 @@ pub(crate) async fn connection(mut input: TunnelConnectionInput) {
                             &input.cbor_rx_send,
                             &mut input.noise_state,
                         )
-                        .await;
+                        .await
+                        {
+                            Ok(RecvOutcome::Continue) => {}
+                            Ok(RecvOutcome::PeerShutdown) => return Ok(()),
+                            Err(e) => {
+                                error!(?e, "Fatal error processing inbound frame");
+                                return Err(e);
+                            }
+                        }
                     }
                     Ok(None) => {
                         debug!("Data channel closed, closing connection");
-                        return;
+                        return Ok(());
                     }
                     Err(e) => {
                         error!(?e, "Failed to read encrypted CBOR message");
-                        return;
+                        return Err(e);
                     }
                 }
             }
@@ -323,11 +339,23 @@ pub(crate) async fn connection(mut input: TunnelConnectionInput) {
                     Ctap2CommandCode::AuthenticatorGetInfo => {
                         debug!("Responding to GetInfo request with cached response");
                         let response = CborResponse::new_success_from_slice(&get_info_response_serialized);
-                        let _ = input.cbor_rx_send.send(response).await;
+                        if let Err(e) = input.cbor_rx_send.send(response).await {
+                            error!(?e, "CBOR response receiver dropped");
+                            return Err(TransportError::ConnectionFailed);
+                        }
                     }
                     _ => {
                         debug!(?request.command, "Sending CBOR request");
-                        let _ = connection_send(request, &mut *input.data_channel, &mut input.noise_state).await;
+                        if let Err(e) = connection_send(
+                            request,
+                            &mut *input.data_channel,
+                            &mut input.noise_state,
+                        )
+                        .await
+                        {
+                            error!(?e, "Fatal error sending CBOR request");
+                            return Err(e);
+                        }
                     }
                 }
             }
@@ -339,7 +367,7 @@ async fn connection_send(
     request: CborRequest,
     data_channel: &mut dyn CableDataChannel,
     noise_state: &mut TunnelNoiseState,
-) -> Result<(), Error> {
+) -> Result<(), TransportError> {
     debug!("Sending CBOR request");
     trace!(?request);
 
@@ -351,7 +379,7 @@ async fn connection_send(
             cbor_request_len = cbor_request.len(),
             "CBOR request too large"
         );
-        return Err(Error::Transport(TransportError::InvalidFraming));
+        return Err(TransportError::InvalidFraming);
     }
     trace!(?cbor_request, cbor_request_len = cbor_request.len());
 
@@ -378,7 +406,7 @@ async fn connection_send(
         }
         Err(e) => {
             error!(?e, "Failed to encrypt frame");
-            return Err(Error::Transport(TransportError::ConnectionFailed));
+            return Err(TransportError::EncryptionFailed);
         }
     }
 
@@ -392,12 +420,12 @@ async fn connection_send(
 /// Strip the trailing padding-length byte and `padding_len` bytes of padding
 /// from a decrypted Noise transport frame, returning `InvalidFraming` on an
 /// empty plaintext or a declared padding length that exceeds the frame.
-fn strip_frame_padding(mut decrypted_frame: Vec<u8>) -> Result<Vec<u8>, Error> {
+fn strip_frame_padding(mut decrypted_frame: Vec<u8>) -> Result<Vec<u8>, TransportError> {
     let padding_len = match decrypted_frame.last() {
         Some(&b) => b as usize,
         None => {
             error!("Decrypted frame is empty; cannot read padding length");
-            return Err(Error::Transport(TransportError::InvalidFraming));
+            return Err(TransportError::InvalidFraming);
         }
     };
     let new_len = decrypted_frame
@@ -408,7 +436,7 @@ fn strip_frame_padding(mut decrypted_frame: Vec<u8>) -> Result<Vec<u8>, Error> {
                 frame_len = decrypted_frame.len(),
                 padding_len, "Padding length exceeds frame length"
             );
-            Error::Transport(TransportError::InvalidFraming)
+            TransportError::InvalidFraming
         })?;
     decrypted_frame.truncate(new_len);
     Ok(decrypted_frame)
@@ -417,7 +445,7 @@ fn strip_frame_padding(mut decrypted_frame: Vec<u8>) -> Result<Vec<u8>, Error> {
 async fn decrypt_frame(
     encrypted_frame: Vec<u8>,
     noise_state: &mut TunnelNoiseState,
-) -> Result<Vec<u8>, Error> {
+) -> Result<Vec<u8>, TransportError> {
     let mut decrypted_frame = vec![0u8; MAX_CBOR_SIZE];
     match noise_state
         .transport_state
@@ -430,7 +458,7 @@ async fn decrypt_frame(
         }
         Err(e) => {
             error!(?e, "Failed to decrypt CBOR response");
-            return Err(Error::Transport(TransportError::ConnectionFailed));
+            return Err(TransportError::EncryptionFailed);
         }
     }
 
@@ -447,14 +475,14 @@ async fn decrypt_frame(
 async fn connection_recv_initial(
     encrypted_frame: Vec<u8>,
     noise_state: &mut TunnelNoiseState,
-) -> Result<Vec<u8>, Error> {
+) -> Result<Vec<u8>, TransportError> {
     let decrypted_frame = decrypt_frame(encrypted_frame, noise_state).await?;
 
     let initial_message: CableInitialMessage = match cbor::from_slice(&decrypted_frame) {
         Ok(initial_message) => initial_message,
         Err(e) => {
             error!(?e, "Failed to decode initial message");
-            return Err(Error::Transport(TransportError::ConnectionFailed));
+            return Err(TransportError::InvalidFraming);
         }
     };
 
@@ -462,14 +490,16 @@ async fn connection_recv_initial(
         Ok(get_info_response) => get_info_response,
         Err(e) => {
             error!(?e, "Failed to decode GetInfo response");
-            return Err(Error::Transport(TransportError::ConnectionFailed));
+            return Err(TransportError::InvalidFraming);
         }
     };
 
     Ok(initial_message.info.to_vec())
 }
 
-async fn connection_recv_update(message: &[u8]) -> Result<Option<CableLinkingInfo>, Error> {
+async fn connection_recv_update(
+    message: &[u8],
+) -> Result<Option<CableLinkingInfo>, TransportError> {
     // TODO(#66): Android adds a 999-key to the end the message, which is not part of the standard.
     // For now, we parse the message to a map and manuually import fields.
 
@@ -477,7 +507,7 @@ async fn connection_recv_update(message: &[u8]) -> Result<Option<CableLinkingInf
         Ok(update_message) => update_message,
         Err(e) => {
             error!(?e, "Failed to decode update message");
-            return Err(Error::Transport(TransportError::ConnectionFailed));
+            return Err(TransportError::InvalidFraming);
         }
     };
 
@@ -539,27 +569,24 @@ async fn connection_recv(
     encrypted_frame: Vec<u8>,
     cbor_rx_send: &Sender<CborResponse>,
     noise_state: &mut TunnelNoiseState,
-) -> Result<(), Error> {
+) -> Result<RecvOutcome, TransportError> {
     let decrypted_frame = decrypt_frame(encrypted_frame, noise_state).await?;
 
-    // TODO handle the decrypted frame
     let cable_message: CableTunnelMessage = match CableTunnelMessage::from_slice(&decrypted_frame) {
         Ok(cable_message) => cable_message,
         Err(e) => {
             error!(?e, "Failed to decode CABLE tunnel message");
-            return Err(Error::Transport(TransportError::ConnectionFailed));
+            return Err(TransportError::InvalidFraming);
         }
     };
 
     trace!(?cable_message);
     match cable_message.message_type {
         CableTunnelMessageType::Shutdown => {
-            // Unexpected shutdown message
-            error!("Received unexpected shutdown message");
-            return Err(Error::Transport(TransportError::ConnectionFailed));
+            debug!("Peer sent Shutdown control message; closing connection cleanly");
+            Ok(RecvOutcome::PeerShutdown)
         }
         CableTunnelMessageType::Ctap => {
-            // Handle the CTAP message
             let cbor_response: CborResponse = (&cable_message.payload.to_vec())
                 .try_into()
                 .or(Err(TransportError::InvalidFraming))?;
@@ -570,20 +597,26 @@ async fn connection_recv(
                 .send(cbor_response)
                 .await
                 .or(Err(TransportError::ConnectionFailed))?;
+            Ok(RecvOutcome::Continue)
         }
         CableTunnelMessageType::Update => {
-            // Handle the update message
-            let maybe_update_message: Option<CableLinkingInfo> =
-                connection_recv_update(&cable_message.payload).await?;
+            // Malformed or unsigned update: log, drop the update, keep the channel.
+            let maybe_update_message = match connection_recv_update(&cable_message.payload).await {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(?e, "Malformed update message; ignoring");
+                    return Ok(RecvOutcome::Continue);
+                }
+            };
 
             let Some(linking_info) = maybe_update_message else {
                 warn!("Ignoring update message without linking info");
-                return Ok(());
+                return Ok(RecvOutcome::Continue);
             };
 
             let CableTunnelConnectionType::QrCode { private_key, .. } = connection_type else {
                 warn!("Ignoring update message for non-QR code connection");
-                return Ok(());
+                return Ok(RecvOutcome::Continue);
             };
 
             debug!("Received update message with linking info");
@@ -600,12 +633,11 @@ async fn connection_recv(
                             store.put_known_device(&device_id, &known_device).await;
                         }
                         Err(e) => {
-                            error!(
+                            warn!(
                                 ?e,
-                                "Invalid update message from authenticator, forgetting device"
+                                "Invalid linking update from authenticator, forgetting device"
                             );
                             store.delete_known_device(&device_id).await;
-                            return Err(Error::Transport(TransportError::TransportUnavailable));
                         }
                     }
                 }
@@ -613,10 +645,9 @@ async fn connection_recv(
                     warn!("Ignoring update message without a device store");
                 }
             };
+            Ok(RecvOutcome::Continue)
         }
-    };
-
-    Ok(())
+    }
 }
 
 /// Validation requires a shared key computed on the QR code ephemeral identity key (private_key here).
@@ -628,15 +659,16 @@ fn parse_known_device(
     tunnel_domain: &str,
     linking_info: &CableLinkingInfo,
     noise_state: &TunnelNoiseState,
-) -> Result<CableKnownDeviceInfo, Error> {
-    let known_device = CableKnownDeviceInfo::new(tunnel_domain, linking_info)?;
+) -> Result<CableKnownDeviceInfo, TransportError> {
+    let known_device = CableKnownDeviceInfo::new(tunnel_domain, linking_info)
+        .map_err(|_| TransportError::InvalidFraming)?;
     let secret_key = SecretKey::from(private_key);
 
     let Ok(authenticator_public_key) =
         PublicKey::from_sec1_bytes(&linking_info.authenticator_public_key)
     else {
         error!("Failed to parse public key.");
-        return Err(Error::Transport(TransportError::InvalidKey));
+        return Err(TransportError::InvalidKey);
     };
 
     let shared_secret: Vec<u8> = ecdh::diffie_hellman(
@@ -646,15 +678,15 @@ fn parse_known_device(
     .raw_secret_bytes()
     .to_vec();
 
-    let mut hmac = Hmac::<Sha256>::new_from_slice(&shared_secret)
-        .map_err(|_| Error::Transport(TransportError::InvalidKey))?;
+    let mut hmac =
+        Hmac::<Sha256>::new_from_slice(&shared_secret).map_err(|_| TransportError::InvalidKey)?;
     hmac.update(&noise_state.handshake_hash);
     let expected_mac = hmac.finalize().into_bytes().to_vec();
 
     if expected_mac != linking_info.handshake_signature {
         error!("Invalid handshake signature, rejecting update message");
         trace!(?expected_mac, ?linking_info.handshake_signature);
-        return Err(Error::Transport(TransportError::InvalidSignature));
+        return Err(TransportError::InvalidSignature);
     }
 
     debug!("Parsed known device with valid signature");
@@ -668,10 +700,7 @@ mod tests {
     #[test]
     fn strip_frame_padding_rejects_empty() {
         let result = strip_frame_padding(Vec::new());
-        assert!(matches!(
-            result,
-            Err(Error::Transport(TransportError::InvalidFraming))
-        ));
+        assert!(matches!(result, Err(TransportError::InvalidFraming)));
     }
 
     #[test]
@@ -679,10 +708,7 @@ mod tests {
         // Length 1 + declared padding of 5 -> would require subtracting 6 from 1.
         let frame = vec![0x05u8];
         let result = strip_frame_padding(frame);
-        assert!(matches!(
-            result,
-            Err(Error::Transport(TransportError::InvalidFraming))
-        ));
+        assert!(matches!(result, Err(TransportError::InvalidFraming)));
     }
 
     #[test]

--- a/libwebauthn/src/transport/cable/protocol.rs
+++ b/libwebauthn/src/transport/cable/protocol.rs
@@ -23,7 +23,6 @@ use crate::proto::ctap2::{Ctap2CommandCode, Ctap2GetInfoResponse};
 use crate::transport::cable::connection_stages::TunnelConnectionInput;
 use crate::transport::cable::known_devices::CableKnownDeviceId;
 use crate::transport::error::TransportError;
-use crate::webauthn::error::Error;
 
 const P256_X962_LENGTH: usize = 65;
 const MAX_CBOR_SIZE: usize = 1024 * 1024;
@@ -45,12 +44,10 @@ impl CableTunnelMessage {
             payload: ByteBuf::from(payload.to_vec()),
         }
     }
-    pub fn from_slice(slice: &[u8]) -> Result<Self, Error> {
-        let (type_byte, payload) = slice
-            .split_first()
-            .ok_or(Error::Transport(TransportError::InvalidFraming))?;
+    pub fn from_slice(slice: &[u8]) -> Result<Self, TransportError> {
+        let (type_byte, payload) = slice.split_first().ok_or(TransportError::InvalidFraming)?;
         if payload.is_empty() {
-            return Err(Error::Transport(TransportError::InvalidFraming));
+            return Err(TransportError::InvalidFraming);
         }
 
         let message_type = match *type_byte {
@@ -58,7 +55,7 @@ impl CableTunnelMessage {
             1 => CableTunnelMessageType::Ctap,
             2 => CableTunnelMessageType::Update,
             _ => {
-                return Err(Error::Transport(TransportError::InvalidFraming));
+                return Err(TransportError::InvalidFraming);
             }
         };
 
@@ -572,13 +569,8 @@ async fn connection_recv(
 ) -> Result<RecvOutcome, TransportError> {
     let decrypted_frame = decrypt_frame(encrypted_frame, noise_state).await?;
 
-    let cable_message: CableTunnelMessage = match CableTunnelMessage::from_slice(&decrypted_frame) {
-        Ok(cable_message) => cable_message,
-        Err(e) => {
-            error!(?e, "Failed to decode CABLE tunnel message");
-            return Err(TransportError::InvalidFraming);
-        }
-    };
+    let cable_message: CableTunnelMessage = CableTunnelMessage::from_slice(&decrypted_frame)
+        .inspect_err(|e| error!(?e, "Failed to decode CABLE tunnel message"))?;
 
     trace!(?cable_message);
     match cable_message.message_type {
@@ -660,8 +652,7 @@ fn parse_known_device(
     linking_info: &CableLinkingInfo,
     noise_state: &TunnelNoiseState,
 ) -> Result<CableKnownDeviceInfo, TransportError> {
-    let known_device = CableKnownDeviceInfo::new(tunnel_domain, linking_info)
-        .map_err(|_| TransportError::InvalidFraming)?;
+    let known_device = CableKnownDeviceInfo::new(tunnel_domain, linking_info)?;
     let secret_key = SecretKey::from(private_key);
 
     let Ok(authenticator_public_key) =

--- a/libwebauthn/src/transport/cable/qr_code_device.rs
+++ b/libwebauthn/src/transport/cable/qr_code_device.rs
@@ -271,11 +271,17 @@ impl<'d> Device<'d, Cable, CableChannel> for CableQrCodeDevice {
                 cbor_tx_recv,
                 cbor_rx_send,
             );
-            protocol::connection(tunnel_input).await;
-
-            ux_sender
-                .set_connection_state(ConnectionState::Terminated)
-                .await;
+            match protocol::connection(tunnel_input).await {
+                Ok(()) => {
+                    ux_sender
+                        .set_connection_state(ConnectionState::Terminated)
+                        .await;
+                }
+                Err(e) => {
+                    // send_error already transitions to Terminated.
+                    ux_sender.send_error(e).await;
+                }
+            }
         });
 
         Ok(CableChannel {

--- a/libwebauthn/src/transport/error.rs
+++ b/libwebauthn/src/transport/error.rs
@@ -22,6 +22,9 @@ pub enum TransportError {
     InvalidSignature,
     #[error("input/output error: {0}")]
     IoError(std::io::ErrorKind),
+    /// Noise transport-mode encrypt or decrypt failed; the channel is unusable.
+    #[error("encryption failed")]
+    EncryptionFailed,
 }
 
 impl From<snow::Error> for TransportError {


### PR DESCRIPTION
## Summary

Stacked on `feat/pxp-ble` (#216).

`protocol::connection` previously returned `()` and swallowed every post-handshake fault via `let _ = ...`: Noise decrypt/encrypt failures, malformed framing inside the encrypted channel, dropped CBOR-response receivers and transport-level I/O errors. The connection silently degraded (subsequent frames keep failing the same way) and the channel eventually moved to `Terminated` without ever emitting `CableUxUpdate::CableUpdate(CableUpdate::Error(_))`. Subscribers had no way to distinguish a clean close from a fault.

## Behaviour changes

- `protocol::connection` returns `Result<(), TransportError>`. Each arm of the select loop is explicit about whether a condition is fatal (exit) or benign (continue + log).
- A new `TransportError::EncryptionFailed` variant is emitted for Noise transport-mode encrypt/decrypt failures, distinct from handshake-time `NegotiationFailed` and generic `ConnectionFailed`.
- A peer-sent `CableTunnelMessageType::Shutdown` is treated as a clean close (returns `Ok(())`) instead of an "unexpected" error.
- Malformed or unsigned linking updates are logged and dropped without tearing the channel down: the Noise state is intact and only that one update is unusable. Matches Chromium.
- `qr_code_device` and `known_devices` route `Err(_)` from the tunnel loop through `UxUpdateSender::send_error`, which already transitions to `Terminated`.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`