### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "libwebauthn"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes",
  "apdu",

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libwebauthn"
 description = "FIDO2 (WebAuthn) and FIDO U2F platform library for Linux written in Rust "
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Alfie Fresta <alfie.fresta@gmail.com>"]
 edition = "2021"
 license-file = "../COPYING"


### PR DESCRIPTION
Bumps libwebauthn to 0.5.0.

Highlights since 0.3.0:
- New CTAP 2.3 hybrid transport over direct BLE L2CAP
- DAFSA-format Public Suffix List reader (with system auto-detection)
- WebAuthn appid / appidExclude extensions
- hmac-secret-mc CTAP 2.2 extension
- PRF input length aligned with WebAuthn L3
- HID wall-clock timeouts and continuation-packet validation hardening
- BLE notifications, write-with-response, and LE secure connections check
- Workspace split: libwebauthn (publishable) + libwebauthn-tests