### PR TITLE
fix(cable): return ConnectionFailed for both Terminated paths

### DIFF
--- a/libwebauthn/src/transport/cable/channel.rs
+++ b/libwebauthn/src/transport/cable/channel.rs
@@ -55,9 +55,13 @@ impl CableChannel {
             return Ok(());
         }
 
-        // If already terminated, return error immediately
+        // If already terminated, return error immediately. Mirror the
+        // post-`changed()` branch below so that an early-terminated channel
+        // surfaces the same variant as one that terminates while we wait;
+        // the caller can't observe the timing difference and the asymmetry
+        // was accidental.
         if *rx.borrow() == ConnectionState::Terminated {
-            return Err(Error::Transport(TransportError::ConnectionLost));
+            return Err(Error::Transport(TransportError::ConnectionFailed));
         }
 
         // Wait for state change


### PR DESCRIPTION
## Summary
`wait_for_connection` returned `ConnectionLost` on an entry-time `Terminated` but `ConnectionFailed` on a transition-time `Terminated`. The caller can't observe which path it took, so the two variants are an accidental asymmetry that makes downstream `match`es fragile. Both paths now return `ConnectionFailed`.

## Test plan
- [ ] `cargo build -p libwebauthn`
- [ ] `cargo test -p libwebauthn`