### PR TITLE
fix(cable): GetInfo timing out before BLE handshake completes

### DIFF
--- a/libwebauthn/src/proto/ctap2/protocol.rs
+++ b/libwebauthn/src/proto/ctap2/protocol.rs
@@ -1,12 +1,10 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tokio::time::timeout as tokio_timeout;
 use tracing::{debug, instrument, trace, warn};
 
-use crate::proto::ctap2::cbor::{self, CborRequest, CborResponse};
+use crate::proto::ctap2::cbor::{self, CborRequest};
 use crate::proto::ctap2::{Ctap2BioEnrollmentResponse, Ctap2CommandCode};
-use crate::transport::error::TransportError;
 use crate::transport::Channel;
 use crate::unwrap_field;
 use crate::webauthn::error::{CtapError, Error, PlatformError};
@@ -20,21 +18,6 @@ use super::{
 };
 
 const TIMEOUT_GET_INFO: Duration = Duration::from_millis(250);
-
-/// CBOR send + recv with a wall-clock timeout over the pair. Mirrors
-/// `send_apdu_request_wait_uv` in the CTAP1 module.
-async fn cbor_send_recv<C: Channel + ?Sized>(
-    channel: &mut C,
-    request: &CborRequest,
-    timeout: Duration,
-) -> Result<CborResponse, Error> {
-    tokio_timeout(timeout, async {
-        channel.cbor_send(request, timeout).await?;
-        channel.cbor_recv(timeout).await
-    })
-    .await
-    .map_err(|_| Error::Transport(TransportError::Timeout))?
-}
 
 macro_rules! parse_cbor {
     ($type:ty, $data:expr) => {{
@@ -100,7 +83,8 @@ where
     #[instrument(skip_all)]
     async fn ctap2_get_info(&mut self) -> Result<Ctap2GetInfoResponse, Error> {
         let cbor_request = CborRequest::new(Ctap2CommandCode::AuthenticatorGetInfo);
-        let cbor_response = cbor_send_recv(self, &cbor_request, TIMEOUT_GET_INFO).await?;
+        self.cbor_send(&cbor_request, TIMEOUT_GET_INFO).await?;
+        let cbor_response = self.cbor_recv(TIMEOUT_GET_INFO).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -119,7 +103,8 @@ where
         timeout: Duration,
     ) -> Result<Ctap2MakeCredentialResponse, Error> {
         trace!(?request);
-        let cbor_response = cbor_send_recv(self, &request.try_into()?, timeout).await?;
+        self.cbor_send(&request.try_into()?, timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -139,7 +124,8 @@ where
         timeout: Duration,
     ) -> Result<Ctap2GetAssertionResponse, Error> {
         trace!(?request);
-        let cbor_response = cbor_send_recv(self, &request.try_into()?, timeout).await?;
+        self.cbor_send(&request.try_into()?, timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -159,7 +145,8 @@ where
     ) -> Result<Ctap2GetAssertionResponse, Error> {
         debug!("CTAP2 GetNextAssertion request");
         let cbor_request = CborRequest::new(Ctap2CommandCode::AuthenticatorGetNextAssertion);
-        let cbor_response = cbor_send_recv(self, &cbor_request, timeout).await?;
+        self.cbor_send(&cbor_request, timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -176,7 +163,8 @@ where
         debug!("CTAP2 Authenticator Selection request");
         let cbor_request = CborRequest::new(Ctap2CommandCode::AuthenticatorSelection);
 
-        let cbor_response = cbor_send_recv(self, &cbor_request, timeout).await?;
+        self.cbor_send(&cbor_request, timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => {
                 return Ok(());
@@ -195,7 +183,8 @@ where
         timeout: Duration,
     ) -> Result<Ctap2ClientPinResponse, Error> {
         trace!(?request);
-        let cbor_response = cbor_send_recv(self, &request.try_into()?, timeout).await?;
+        self.cbor_send(&request.try_into()?, timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -220,7 +209,8 @@ where
         timeout: Duration,
     ) -> Result<(), Error> {
         trace!(?request);
-        let cbor_response = cbor_send_recv(self, &request.try_into()?, timeout).await?;
+        self.cbor_send(&request.try_into()?, timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => {
                 return Ok(());
@@ -242,7 +232,8 @@ where
         timeout: Duration,
     ) -> Result<Ctap2BioEnrollmentResponse, Error> {
         trace!(?request);
-        let cbor_response = cbor_send_recv(self, &request.try_into()?, timeout).await?;
+        self.cbor_send(&request.try_into()?, timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -267,7 +258,8 @@ where
         timeout: Duration,
     ) -> Result<Ctap2CredentialManagementResponse, Error> {
         trace!(?request);
-        let cbor_response = cbor_send_recv(self, &request.try_into()?, timeout).await?;
+        self.cbor_send(&request.try_into()?, timeout).await?;
+        let cbor_response = self.cbor_recv(timeout).await?;
         match cbor_response.status_code {
             CtapError::Ok => (),
             error => return Err(Error::Ctap(error)),
@@ -321,6 +313,25 @@ mod tests {
 
         let result = channel.ctap2_get_info().await;
         assert_eq!(result.err(), Some(Error::Ctap(CtapError::Other)));
+    }
+
+    // Regression test: cable's `cbor_send` blocks for the BLE handshake before
+    // the per-leg timeout applies, so the protocol layer must not add an outer
+    // wall-clock timeout that fires while the channel is still handshaking.
+    #[tokio::test]
+    async fn ctap2_get_info_tolerates_slow_cbor_send() {
+        let mut channel = MockChannel::new();
+        channel.set_pre_send_delay(super::TIMEOUT_GET_INFO + Duration::from_millis(50));
+        let expected_request = CborRequest::new(Ctap2CommandCode::AuthenticatorGetInfo);
+        channel.push_command_pair(expected_request, error_response(CtapError::Other));
+
+        let result = channel.ctap2_get_info().await;
+        assert_eq!(
+            result.err(),
+            Some(Error::Ctap(CtapError::Other)),
+            "GetInfo must not impose a wall-clock timeout that fires before \
+             the channel's own cbor_send returns"
+        );
     }
 
     #[tokio::test]

--- a/libwebauthn/src/transport/mock/channel.rs
+++ b/libwebauthn/src/transport/mock/channel.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use std::{collections::VecDeque, fmt::Display, time::Duration};
 use tokio::sync::broadcast;
+use tokio::time::sleep;
 
 use crate::{
     proto::{
@@ -19,6 +20,7 @@ pub struct MockChannel {
     responses: VecDeque<CborResponse>,
     auth_token_data: Option<AuthTokenData>,
     ux_update_sender: broadcast::Sender<UvUpdate>,
+    pre_send_delay: Option<Duration>,
 }
 
 impl Default for MockChannel {
@@ -35,12 +37,18 @@ impl MockChannel {
             responses: VecDeque::new(),
             auth_token_data: None,
             ux_update_sender,
+            pre_send_delay: None,
         }
     }
 
     pub fn push_command_pair(&mut self, expected_request: CborRequest, response: CborResponse) {
         self.expected_requests.push_front(expected_request);
         self.responses.push_front(response);
+    }
+
+    /// Make `cbor_send` sleep for `delay` before completing, modeling a transport that defers the actual send behind a handshake.
+    pub fn set_pre_send_delay(&mut self, delay: Duration) {
+        self.pre_send_delay = Some(delay);
     }
 }
 
@@ -93,6 +101,9 @@ impl Channel for MockChannel {
     }
 
     async fn cbor_send(&mut self, request: &CborRequest, _timeout: Duration) -> Result<(), Error> {
+        if let Some(delay) = self.pre_send_delay {
+            sleep(delay).await;
+        }
         let expected = self
             .expected_requests
             .pop_back()


### PR DESCRIPTION
Hybrid currently fails immediately with `Transport(Timeout)` (issue #225) because the protocol layer wraps each CTAP2 exchange in a 250ms wall-clock timeout, but the cable transport legitimately blocks for the BLE handshake before that timeout window even applies.

Removing the outer wrap is safe. HID already enforces its wall-clock deadline inside its own receive path (the original motivation for the wrap), and the per-leg send and receive timeouts on every transport are unchanged. The change restores the pre-regression shape of the protocol layer and adds a unit test that pins the behaviour by sleeping the mock channel's send past the GetInfo timeout and asserting the call still reaches the response.

Fixes #225