### PR TITLE
chore(release): 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "libwebauthn"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes",
  "apdu",

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libwebauthn"
 description = "FIDO2 (WebAuthn) and FIDO U2F platform library for Linux written in Rust "
-version = "0.5.0"
+version = "0.5.1"
 authors = [
     "Alfie Fresta <afresta@noentropy.org>",
     "Martin Sirringhaus <martin.sirringhaus@suse.com>",


### PR DESCRIPTION
0.5.1 patch release. Bundles the hybrid timeout regression fix from #226 plus the small metadata and error-variant cleanups already on master since 0.5.0.

Fixes #225