### PR TITLE
fix(ctap2): store credential public keys as opaque COSE bytes

### DIFF
--- a/libwebauthn/src/fido.rs
+++ b/libwebauthn/src/fido.rs
@@ -1,5 +1,4 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use cosey::PublicKey;
 use serde::{
     de::{DeserializeOwned, Error as DesError, Visitor},
     Deserialize, Deserializer, Serialize,
@@ -62,7 +61,12 @@ bitflags! {
 pub struct AttestedCredentialData {
     pub aaguid: [u8; 16],
     pub credential_id: Vec<u8>,
-    pub credential_public_key: PublicKey,
+    /// Credential public key in COSE_Key CBOR encoding (RFC 9052).
+    ///
+    /// Stored verbatim so the authenticator data signature over it
+    /// remains valid for relying-party verification. The platform does
+    /// not crypto-validate this key.
+    pub credential_public_key: Vec<u8>,
 }
 
 impl From<&AttestedCredentialData> for Ctap2PublicKeyCredentialDescriptor {
@@ -120,16 +124,7 @@ where
                 Error::Platform(PlatformError::InvalidDeviceResponse)
             })?;
             res.extend(&att_data.credential_id);
-            let cose_encoded_public_key =
-                cbor::to_vec(&att_data.credential_public_key)
-            .map_err(|e| {
-                error!(
-                    %e,
-                    "Failed to create AuthenticatorData output vec at attested_credential.credential_public_key"  
-                );
-                Error::Platform(PlatformError::InvalidDeviceResponse)
-            })?;
-            res.extend(cose_encoded_public_key);
+            res.extend(&att_data.credential_public_key);
         }
 
         if self.extensions.is_some() || self.flags.contains(AuthenticatorDataFlags::EXTENSION_DATA)
@@ -229,8 +224,20 @@ impl<'de, T: DeserializeOwned> Deserialize<'de> for AuthenticatorData<T> {
                             DesError::custom(format!("failed to read credential_id: {e}"))
                         })?;
 
-                        let credential_public_key: PublicKey =
+                        // Capture the COSE_Key bytes verbatim so the RP's
+                        // signature check over authData stays valid. Parse
+                        // through cbor::Value only to advance the cursor by
+                        // exactly one CBOR item.
+                        let cose_start = cursor.position() as usize;
+                        let _: cbor::Value =
                             cbor::from_cursor(&mut cursor).map_err(DesError::custom)?;
+                        let cose_end = cursor.position() as usize;
+                        let credential_public_key = data
+                            .get(cose_start..cose_end)
+                            .ok_or_else(|| {
+                                DesError::custom("cursor reported COSE_Key span outside authData")
+                            })?
+                            .to_vec();
 
                         Some(AttestedCredentialData {
                             aaguid,
@@ -273,7 +280,6 @@ impl<'de, T: DeserializeOwned> Deserialize<'de> for AuthenticatorData<T> {
 
 #[cfg(test)]
 mod tests {
-    use cosey::{Bytes, Ed25519PublicKey};
     use serde_bytes::ByteBuf;
 
     use crate::proto::ctap2::cbor;
@@ -301,9 +307,6 @@ mod tests {
         ];
         let credential_id = vec![0x01, 0x01, 0x03, 0x03, 0x05, 0x05, 0x07, 0x07];
         let pub_key_bytes = b"]\"\xff\xc5\x932x(\xd6-:1\xbb}\x8c$7\xf1&\xd4\xb4&\x02\x02\xa3\xd9\xe2\xba1\x1f\xec\xba";
-        let credential_public_key = cosey::PublicKey::Ed25519Key(Ed25519PublicKey {
-            x: Bytes::from_slice(pub_key_bytes).unwrap(),
-        });
         /*
          * A4                                      # map(4)
          *    01                                   # unsigned(1) kty
@@ -321,7 +324,7 @@ mod tests {
         let attested_credential = AttestedCredentialData {
             aaguid,
             credential_id: credential_id.clone(),
-            credential_public_key,
+            credential_public_key: cose_bytes.clone(),
         };
         type T = String;
         let extensions: T = "test cbor serializable thing".to_string();
@@ -376,5 +379,56 @@ mod tests {
             attested_credential_reparsed.credential_public_key
         );
         assert_eq!(extensions, auth_data_reparsed.extensions.unwrap());
+    }
+
+    #[test]
+    fn auth_data_parses_with_non_p256_credential_public_key() {
+        // Build a synthetic COSE_Key for RS256 (kty=3 RSA, alg=-257, n, e).
+        // Previous versions of libwebauthn couldn't parse authData carrying
+        // anything other than P-256 or Ed25519 because cosey::PublicKey is
+        // a closed enum. With opaque byte storage this now round-trips.
+        use crate::proto::ctap2::cose;
+        use serde_cbor_2::Value;
+
+        let rsa_cose = cbor::to_vec(&Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(3)),
+                (Value::Integer(3), Value::Integer(-257)),
+                (Value::Integer(-1), Value::Bytes(vec![0xAA; 256])),
+                (Value::Integer(-2), Value::Bytes(vec![0x01, 0x00, 0x01])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap();
+
+        let rp_id_hash = [0x77u8; 32];
+        let aaguid = [0x42u8; 16];
+        let credential_id = vec![0xC1, 0xC2, 0xC3];
+        let attested_credential = AttestedCredentialData {
+            aaguid,
+            credential_id: credential_id.clone(),
+            credential_public_key: rsa_cose.clone(),
+        };
+        type T = String;
+        let auth_data: AuthenticatorData<T> = AuthenticatorData {
+            rp_id_hash,
+            flags: AuthenticatorDataFlags::USER_PRESENT
+                | AuthenticatorDataFlags::ATTESTED_CREDENTIALS,
+            signature_count: 1,
+            attested_credential: Some(attested_credential),
+            extensions: None,
+        };
+
+        let bytes = auth_data.to_response_bytes().unwrap();
+        let wrapped = cbor::to_vec(&ByteBuf::from(bytes)).unwrap();
+        let parsed: AuthenticatorData<T> = cbor::from_slice(&wrapped).unwrap();
+
+        let credential = parsed.attested_credential.expect("AT flag was set");
+        assert_eq!(credential.credential_public_key, rsa_cose);
+        assert_eq!(
+            cose::read_alg(&credential.credential_public_key).unwrap(),
+            crate::proto::ctap2::Ctap2COSEAlgorithmIdentifier::RS256
+        );
     }
 }

--- a/libwebauthn/src/management/credential_management.rs
+++ b/libwebauthn/src/management/credential_management.rs
@@ -169,7 +169,7 @@ where
         let cred = Ctap2CredentialData::new(
             unwrap_field!(resp.user),
             unwrap_field!(resp.credential_id),
-            unwrap_field!(resp.public_key),
+            unwrap_field!(resp.public_key).into_bytes(),
             unwrap_field!(resp.cred_protect),
             resp.large_blob_key.map(|x| x.into_vec()),
         );
@@ -202,7 +202,7 @@ where
         let cred = Ctap2CredentialData::new(
             unwrap_field!(resp.user),
             unwrap_field!(resp.credential_id),
-            unwrap_field!(resp.public_key),
+            unwrap_field!(resp.public_key).into_bytes(),
             unwrap_field!(resp.cred_protect),
             resp.large_blob_key.map(|x| x.into_vec()),
         );

--- a/libwebauthn/src/ops/u2f.rs
+++ b/libwebauthn/src/ops/u2f.rs
@@ -114,7 +114,7 @@ impl UpgradableResponse<MakeCredentialResponse, MakeCredentialRequest> for Regis
         let attested_cred_data = AttestedCredentialData {
             aaguid: [0u8; 16], // aaguid zeros
             credential_id: self.key_handle.clone(),
-            credential_public_key: cose_public_key,
+            credential_public_key: cose_encoded_public_key,
         };
 
         // Initialize authenticatorData:

--- a/libwebauthn/src/ops/webauthn/make_credential.rs
+++ b/libwebauthn/src/ops/webauthn/make_credential.rs
@@ -26,8 +26,8 @@ use crate::{
     proto::{
         ctap1::{Ctap1RegisteredKey, Ctap1Version},
         ctap2::{
-            cbor, Ctap2AttestationStatement, Ctap2COSEAlgorithmIdentifier, Ctap2CredentialType,
-            Ctap2GetInfoResponse, Ctap2MakeCredentialsResponseExtensions,
+            cbor, cose, Ctap2AttestationStatement, Ctap2COSEAlgorithmIdentifier,
+            Ctap2CredentialType, Ctap2GetInfoResponse, Ctap2MakeCredentialsResponseExtensions,
             Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
             Ctap2PublicKeyCredentialUserEntity,
         },
@@ -67,42 +67,33 @@ impl WebAuthnIDLResponse for MakeCredentialResponse {
         &self,
         request: &Self::Context,
     ) -> Result<Self::IdlModel, ResponseSerializationError> {
-        // Get credential ID from attested credential data
-        let credential_id_bytes = self
+        // The AT flag MUST be set on makeCredential responses per CTAP §6.1.
+        let attested = self
             .authenticator_data
             .attested_credential
             .as_ref()
-            .map(|cred| cred.credential_id.clone())
-            .unwrap_or_default();
+            .ok_or_else(|| {
+                ResponseSerializationError::AuthenticatorDataError(
+                    "missing attested credential data".into(),
+                )
+            })?;
 
-        let id = base64_url::encode(&credential_id_bytes);
-        let raw_id = Base64UrlString::from(credential_id_bytes);
+        let id = base64_url::encode(&attested.credential_id);
+        let raw_id = Base64UrlString::from(attested.credential_id.clone());
 
-        // Serialize authenticator data
         let authenticator_data_bytes = self
             .authenticator_data
             .to_response_bytes()
             .map_err(|e| ResponseSerializationError::AuthenticatorDataError(e.to_string()))?;
 
-        // Get public key algorithm from attested credential data
-        let public_key_algorithm = self
-            .authenticator_data
-            .attested_credential
-            .as_ref()
-            .map(|cred| Self::get_public_key_algorithm(&cred.credential_public_key))
-            .unwrap_or_else(|| i64::from(Ctap2COSEAlgorithmIdentifier::ES256));
+        let public_key_algorithm = i64::from(
+            cose::read_alg(&attested.credential_public_key)
+                .map_err(|e| ResponseSerializationError::PublicKeyError(e.to_string()))?,
+        );
 
-        // Serialize public key to COSE key format
-        let public_key = self
-            .authenticator_data
-            .attested_credential
-            .as_ref()
-            .map(|cred| {
-                cbor::to_vec(&cred.credential_public_key)
-                    .map(Base64UrlString::from)
-                    .map_err(|e| ResponseSerializationError::PublicKeyError(e.to_string()))
-            })
-            .transpose()?;
+        let public_key = Some(Base64UrlString::from(
+            attested.credential_public_key.clone(),
+        ));
 
         // Build attestation object (CBOR map with authData, fmt, attStmt)
         let attestation_object_bytes = self.build_attestation_object(&authenticator_data_bytes)?;
@@ -132,16 +123,6 @@ impl WebAuthnIDLResponse for MakeCredentialResponse {
 }
 
 impl MakeCredentialResponse {
-    /// Get the COSE algorithm identifier from the public key variant
-    fn get_public_key_algorithm(key: &cosey::PublicKey) -> i64 {
-        match key {
-            cosey::PublicKey::P256Key(_) => i64::from(Ctap2COSEAlgorithmIdentifier::ES256),
-            cosey::PublicKey::EcdhEsHkdf256Key(_) => -25, // ECDH-ES + HKDF-256
-            cosey::PublicKey::Ed25519Key(_) => i64::from(Ctap2COSEAlgorithmIdentifier::EDDSA),
-            cosey::PublicKey::TotpKey(_) => 0, // No standard algorithm for TOTP
-        }
-    }
-
     fn build_attestation_object(
         &self,
         authenticator_data_bytes: &[u8],
@@ -1083,16 +1064,18 @@ mod tests {
         let credential_id = vec![0x01, 0x02, 0x03, 0x04];
         let aaguid = [0u8; 16];
 
-        // Create a P256 public key for testing
-        let public_key = cosey::PublicKey::P256Key(cosey::P256PublicKey {
+        // Minimal COSE_Key for a P-256 ES256 credential, used as opaque
+        // bytes by the test harness.
+        let cose_public_key = cosey::PublicKey::P256Key(cosey::P256PublicKey {
             x: Bytes::from_slice(&[0u8; 32]).unwrap(),
             y: Bytes::from_slice(&[0u8; 32]).unwrap(),
         });
+        let credential_public_key = cbor::to_vec(&cose_public_key).unwrap();
 
         let attested_credential = AttestedCredentialData {
             aaguid,
             credential_id,
-            credential_public_key: public_key,
+            credential_public_key,
         };
 
         let authenticator_data = AuthenticatorData {

--- a/libwebauthn/src/ops/webauthn/make_credential.rs
+++ b/libwebauthn/src/ops/webauthn/make_credential.rs
@@ -67,7 +67,7 @@ impl WebAuthnIDLResponse for MakeCredentialResponse {
         &self,
         request: &Self::Context,
     ) -> Result<Self::IdlModel, ResponseSerializationError> {
-        // The AT flag MUST be set on makeCredential responses per CTAP §6.1.
+        // The AT flag MUST be set on makeCredential responses per CTAP 2.2 §6.1.
         let attested = self
             .authenticator_data
             .attested_credential

--- a/libwebauthn/src/proto/ctap2/cose.rs
+++ b/libwebauthn/src/proto/ctap2/cose.rs
@@ -1,0 +1,189 @@
+//! Helpers for COSE_Key blobs carried opaquely on the CTAP wire.
+//!
+//! libwebauthn shuttles credential public keys between authenticator and
+//! relying party as raw COSE bytes per [RFC 9052]. The platform layer only
+//! needs to read the `alg` parameter (mandatory per WebAuthn L3 §6.5.2) so
+//! it can populate `getPublicKeyAlgorithm()` and decide whether to build a
+//! `SubjectPublicKeyInfo` in `getPublicKey()`. Everything else stays as
+//! bytes for the RP to validate.
+//!
+//! [RFC 9052]: https://www.rfc-editor.org/rfc/rfc9052.html
+
+use serde::{Deserialize, Deserializer};
+use serde_cbor_2::Value;
+use tracing::warn;
+
+use crate::proto::ctap2::Ctap2COSEAlgorithmIdentifier;
+use crate::webauthn::{Error, PlatformError};
+
+/// COSE Key Common Parameter `alg`, label 3 ([RFC 9052] §7.1).
+const COSE_KEY_LABEL_ALG: i128 = 3;
+
+/// A COSE_Key captured opaquely as CBOR bytes.
+///
+/// The platform layer does not crypto-validate credential public keys, so
+/// it stores them as bytes and forwards them to the RP. Use [`read_alg`]
+/// to extract the algorithm identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoseEncodedKey(pub Vec<u8>);
+
+impl CoseEncodedKey {
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for CoseEncodedKey {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(deserializer)?;
+        let bytes = serde_cbor_2::to_vec(&value).map_err(serde::de::Error::custom)?;
+        Ok(CoseEncodedKey(bytes))
+    }
+}
+
+/// Read the `alg` parameter from a COSE_Key encoded as CBOR bytes.
+///
+/// Per WebAuthn L3 §6.5.2, every credential public key MUST include the
+/// `alg` parameter. A missing, non-integer, or out-of-range value is
+/// treated as an invalid device response.
+pub(crate) fn read_alg(bytes: &[u8]) -> Result<Ctap2COSEAlgorithmIdentifier, Error> {
+    let value: Value = serde_cbor_2::from_slice(bytes).map_err(|e| {
+        warn!(%e, "failed to parse COSE_Key as CBOR");
+        Error::Platform(PlatformError::InvalidDeviceResponse)
+    })?;
+
+    let Value::Map(map) = value else {
+        warn!("COSE_Key is not a CBOR map");
+        return Err(Error::Platform(PlatformError::InvalidDeviceResponse));
+    };
+
+    let alg_value = map
+        .get(&Value::Integer(COSE_KEY_LABEL_ALG))
+        .ok_or_else(|| {
+            warn!("COSE_Key missing required `alg` parameter");
+            Error::Platform(PlatformError::InvalidDeviceResponse)
+        })?;
+
+    let Value::Integer(alg) = alg_value else {
+        warn!("COSE_Key `alg` is not an integer");
+        return Err(Error::Platform(PlatformError::InvalidDeviceResponse));
+    };
+
+    let alg_i32 = i32::try_from(*alg).map_err(|_| {
+        warn!(alg = %alg, "COSE_Key `alg` outside i32 range");
+        Error::Platform(PlatformError::InvalidDeviceResponse)
+    })?;
+
+    Ok(Ctap2COSEAlgorithmIdentifier(alg_i32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::ctap2::cbor;
+
+    /// Minimal COSE_Key for ES256 P-256 (matches the canonical example in
+    /// RFC 9053 §2.1).
+    fn cose_key_es256() -> Vec<u8> {
+        // {1: 2, 3: -7, -1: 1, -2: <32 bytes>, -3: <32 bytes>}
+        cbor::to_vec(&serde_cbor_2::value::Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(2)),
+                (Value::Integer(3), Value::Integer(-7)),
+                (Value::Integer(-1), Value::Integer(1)),
+                (Value::Integer(-2), Value::Bytes(vec![0xAA; 32])),
+                (Value::Integer(-3), Value::Bytes(vec![0xBB; 32])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap()
+    }
+
+    /// Minimal COSE_Key for RS256 (RSA, kty=3, alg=-257, n, e).
+    fn cose_key_rs256() -> Vec<u8> {
+        cbor::to_vec(&Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(3)),
+                (Value::Integer(3), Value::Integer(-257)),
+                (Value::Integer(-1), Value::Bytes(vec![0xCC; 256])),
+                (Value::Integer(-2), Value::Bytes(vec![0x01, 0x00, 0x01])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap()
+    }
+
+    /// Synthetic COSE_Key with a future / unrecognised `alg` value.
+    fn cose_key_synthetic_pqc() -> Vec<u8> {
+        cbor::to_vec(&Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(7)),
+                (Value::Integer(3), Value::Integer(-99999)),
+                (Value::Integer(-1), Value::Bytes(vec![0xDD; 2592])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn reads_es256_alg() {
+        let alg = read_alg(&cose_key_es256()).unwrap();
+        assert_eq!(alg, Ctap2COSEAlgorithmIdentifier::ES256);
+        assert!(alg.is_known());
+    }
+
+    #[test]
+    fn reads_rs256_alg() {
+        let alg = read_alg(&cose_key_rs256()).unwrap();
+        assert_eq!(alg, Ctap2COSEAlgorithmIdentifier::RS256);
+        assert!(alg.is_known());
+    }
+
+    #[test]
+    fn reads_unknown_alg_without_rewriting() {
+        let alg = read_alg(&cose_key_synthetic_pqc()).unwrap();
+        assert_eq!(alg, Ctap2COSEAlgorithmIdentifier(-99999));
+        assert!(!alg.is_known());
+    }
+
+    #[test]
+    fn rejects_missing_alg() {
+        let bytes = cbor::to_vec(&Value::Map(
+            [(Value::Integer(1), Value::Integer(2))]
+                .into_iter()
+                .collect(),
+        ))
+        .unwrap();
+        assert!(read_alg(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_non_integer_alg() {
+        let bytes = cbor::to_vec(&Value::Map(
+            [(Value::Integer(3), Value::Text("ES256".into()))]
+                .into_iter()
+                .collect(),
+        ))
+        .unwrap();
+        assert!(read_alg(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_non_map_root() {
+        let bytes = cbor::to_vec(&Value::Integer(-7)).unwrap();
+        assert!(read_alg(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_cbor() {
+        assert!(read_alg(&[0xFF, 0xFF, 0xFF]).is_err());
+    }
+}

--- a/libwebauthn/src/proto/ctap2/mod.rs
+++ b/libwebauthn/src/proto/ctap2/mod.rs
@@ -1,9 +1,12 @@
 extern crate async_trait;
 
 pub mod cbor;
+pub mod cose;
 
 mod model;
 mod protocol;
+
+pub use cose::CoseEncodedKey;
 
 pub use model::Ctap2GetInfoResponse;
 #[cfg(test)]

--- a/libwebauthn/src/proto/ctap2/model/credential_management.rs
+++ b/libwebauthn/src/proto/ctap2/model/credential_management.rs
@@ -2,7 +2,7 @@ use super::{
     Ctap2PinUvAuthProtocol, Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialRpEntity,
     Ctap2PublicKeyCredentialUserEntity,
 };
-use cosey::PublicKey;
+use crate::proto::ctap2::CoseEncodedKey;
 use serde_bytes::ByteBuf;
 use serde_indexed::{DeserializeIndexed, SerializeIndexed};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -103,7 +103,7 @@ pub struct Ctap2CredentialManagementResponse {
     // publicKey (0x08) 	COSE_Key 	Public key of the credential.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(index = 0x08)]
-    pub public_key: Option<PublicKey>,
+    pub public_key: Option<CoseEncodedKey>,
 
     // totalCredentials (0x09) 	Unsigned Integer 	Total number of credentials present on the authenticator for the RP in question
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -232,7 +232,8 @@ impl Ctap2CredentialManagementMetadata {
 pub struct Ctap2CredentialData {
     pub user: Ctap2PublicKeyCredentialUserEntity,
     pub credential_id: Ctap2PublicKeyCredentialDescriptor,
-    pub public_key: PublicKey,
+    /// Credential public key in COSE_Key CBOR encoding (RFC 9052).
+    pub public_key: Vec<u8>,
     pub cred_protect: u64,
     /// This is not there in the Preview mode
     pub large_blob_key: Option<Vec<u8>>,
@@ -242,7 +243,7 @@ impl Ctap2CredentialData {
     pub fn new(
         user: Ctap2PublicKeyCredentialUserEntity,
         credential_id: Ctap2PublicKeyCredentialDescriptor,
-        public_key: PublicKey,
+        public_key: Vec<u8>,
         cred_protect: u64,
         large_blob_key: Option<Vec<u8>>,
     ) -> Self {


### PR DESCRIPTION
The credential public key returned by an authenticator was being stored in a closed Rust enum that only handled P-256 and Ed25519. Any credential using RSA, P-384, secp256k1 or a post-quantum algorithm failed to deserialise, so the whole registration response was rejected.

Credential public keys are now stored as raw COSE bytes. The platform doesn't crypto-validate them, it forwards them to the relying party, so the closed enum was over-modelling. The authenticator data parser captures the COSE_Key bytes verbatim, preserving the attestation signature's bit-identity for relying-party verification.

A small helper reads the mandatory `alg` parameter per WebAuthn L3 §6.5.2, which is what populates `publicKeyAlgorithm` in the JSON response. The previous ES256 fallback when attested credential data was missing is removed because the AT flag MUST be set per CTAP §6.1, and a silent fallback was hiding real protocol violations.

The closed enum is still used for the ECDH-ES P-256 key agreement during PIN/UV protocols, where the COSE shape is fixed by spec.

Stacked on top of #228.