### PR TITLE
feat(webauthn): emit SubjectPublicKeyInfo from getPublicKey()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,7 +839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
 dependencies = [
  "crypto-bigint 0.2.5",
- "der_derive",
+ "der_derive 0.4.1",
 ]
 
 [[package]]
@@ -849,6 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive 0.7.3",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -877,6 +878,17 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "synstructure 0.12.6",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1813,6 +1825,7 @@ dependencies = [
  "ctap-types",
  "curve25519-dalek",
  "dbus",
+ "der 0.7.10",
  "futures",
  "heapless",
  "hex",
@@ -1842,6 +1855,7 @@ dependencies = [
  "serde_repr",
  "sha2 0.10.9",
  "snow",
+ "spki",
  "test-log",
  "text_io",
  "thiserror 2.0.18",

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -69,6 +69,8 @@ rand = "0.8.5"
 p256 = { version = "0.13.2", features = ["ecdh", "arithmetic", "serde"] }
 heapless = "0.7"
 cosey = "0.3.2"
+spki = { version = "0.7", default-features = false, features = ["alloc"] }
+der = { version = "0.7", default-features = false, features = ["alloc", "derive", "oid"] }
 aes = "0.8.2"
 hmac = "0.12.1"
 cbc = { version = "0.1", features = ["alloc"] }

--- a/libwebauthn/src/ops/webauthn/make_credential.rs
+++ b/libwebauthn/src/ops/webauthn/make_credential.rs
@@ -91,9 +91,12 @@ impl WebAuthnIDLResponse for MakeCredentialResponse {
                 .map_err(|e| ResponseSerializationError::PublicKeyError(e.to_string()))?,
         );
 
-        let public_key = Some(Base64UrlString::from(
-            attested.credential_public_key.clone(),
-        ));
+        // SubjectPublicKeyInfo per WebAuthn L3 §5.2.1.1. `to_spki` returns
+        // `Ok(None)` for algorithms libwebauthn does not implement, which
+        // surfaces as `getPublicKey() === null` to the relying party.
+        let public_key = cose::to_spki(&attested.credential_public_key)
+            .map_err(|e| ResponseSerializationError::PublicKeyError(e.to_string()))?
+            .map(Base64UrlString::from);
 
         // Build attestation object (CBOR map with authData, fmt, attStmt)
         let attestation_object_bytes = self.build_attestation_object(&authenticator_data_bytes)?;
@@ -1159,6 +1162,35 @@ mod tests {
             i64::from(Ctap2COSEAlgorithmIdentifier::ES256)
         );
         assert!(model.response.transports.is_empty());
+    }
+
+    #[test]
+    fn test_response_emits_spki_for_es256() {
+        // The test fixture builds an ES256 P-256 credential, so getPublicKey()
+        // must return DER-encoded SubjectPublicKeyInfo per WebAuthn L3 §5.2.1.1.
+        // The SPKI for ES256 starts with the SEQUENCE / SEQUENCE / OID prefix
+        // 30 59 30 13 06 07 2A 86 48 CE 3D 02 01 (id-ecPublicKey), followed
+        // by the secp256r1 OID and the uncompressed point.
+        let response = create_test_response();
+        let request = create_test_request();
+        let model = response.to_idl_model(&request).unwrap();
+
+        let public_key_bytes = model
+            .response
+            .public_key
+            .expect("ES256 must produce SPKI")
+            .0;
+        assert_eq!(public_key_bytes.len(), 91, "ES256 SPKI is 91 bytes");
+        // SEQUENCE tag + length, then nested SEQUENCE for AlgorithmIdentifier.
+        assert_eq!(&public_key_bytes[..2], &[0x30, 0x59]);
+        // id-ecPublicKey OID: 1.2.840.10045.2.1
+        let id_ec_public_key = [0x06, 0x07, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x02, 0x01];
+        assert!(
+            public_key_bytes
+                .windows(id_ec_public_key.len())
+                .any(|w| w == id_ec_public_key),
+            "SPKI must contain id-ecPublicKey OID"
+        );
     }
 
     #[test]

--- a/libwebauthn/src/proto/ctap2/cose.rs
+++ b/libwebauthn/src/proto/ctap2/cose.rs
@@ -3,21 +3,46 @@
 //! libwebauthn shuttles credential public keys between authenticator and
 //! relying party as raw COSE bytes per [RFC 9052]. The platform layer only
 //! needs to read the `alg` parameter (mandatory per WebAuthn L3 §6.5.2) so
-//! it can populate `getPublicKeyAlgorithm()` and decide whether to build a
-//! `SubjectPublicKeyInfo` in `getPublicKey()`. Everything else stays as
-//! bytes for the RP to validate.
+//! it can populate `getPublicKeyAlgorithm()` and, for the algorithms it
+//! understands, build a `SubjectPublicKeyInfo` for `getPublicKey()`.
 //!
 //! [RFC 9052]: https://www.rfc-editor.org/rfc/rfc9052.html
 
+use der::asn1::{BitString, Null};
+use der::{Decode, Encode, Sequence};
 use serde::{Deserialize, Deserializer};
 use serde_cbor_2::Value;
+use spki::{AlgorithmIdentifierOwned, ObjectIdentifier, SubjectPublicKeyInfoOwned};
 use tracing::warn;
 
 use crate::proto::ctap2::Ctap2COSEAlgorithmIdentifier;
 use crate::webauthn::{Error, PlatformError};
 
-/// COSE Key Common Parameter `alg`, label 3 ([RFC 9052] §7.1).
+/// COSE Key Common Parameters ([RFC 9052] §7.1).
+const COSE_KEY_LABEL_KTY: i128 = 1;
 const COSE_KEY_LABEL_ALG: i128 = 3;
+
+/// EC2 / OKP key parameters ([RFC 9053] §7.1, §7.2).
+const COSE_KEY_LABEL_CRV: i128 = -1;
+const COSE_KEY_LABEL_X: i128 = -2;
+const COSE_KEY_LABEL_Y: i128 = -3;
+
+/// RSA key parameters ([RFC 8230] §4).
+const COSE_KEY_LABEL_N: i128 = -1;
+const COSE_KEY_LABEL_E: i128 = -2;
+
+const COSE_KTY_OKP: i128 = 1;
+const COSE_KTY_EC2: i128 = 2;
+const COSE_KTY_RSA: i128 = 3;
+
+const COSE_CRV_P256: i128 = 1;
+const COSE_CRV_ED25519: i128 = 6;
+
+/// SPKI algorithm OIDs.
+const OID_EC_PUBLIC_KEY: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");
+const OID_SECP256R1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");
+const OID_ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
+const OID_RSA_ENCRYPTION: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
 
 /// A COSE_Key captured opaquely as CBOR bytes.
 ///
@@ -45,40 +70,213 @@ impl<'de> Deserialize<'de> for CoseEncodedKey {
     }
 }
 
+type CoseMap = std::collections::BTreeMap<Value, Value>;
+
+fn parse_cose_map(bytes: &[u8]) -> Result<CoseMap, Error> {
+    let value: Value = serde_cbor_2::from_slice(bytes).map_err(|e| {
+        warn!(%e, "failed to parse COSE_Key as CBOR");
+        Error::Platform(PlatformError::InvalidDeviceResponse)
+    })?;
+    match value {
+        Value::Map(map) => Ok(map),
+        _ => {
+            warn!("COSE_Key is not a CBOR map");
+            Err(Error::Platform(PlatformError::InvalidDeviceResponse))
+        }
+    }
+}
+
+fn map_integer(map: &CoseMap, label: i128) -> Result<i128, Error> {
+    match map.get(&Value::Integer(label)) {
+        Some(Value::Integer(i)) => Ok(*i),
+        Some(_) => {
+            warn!(label, "COSE_Key field is not an integer");
+            Err(Error::Platform(PlatformError::InvalidDeviceResponse))
+        }
+        None => {
+            warn!(label, "COSE_Key missing required field");
+            Err(Error::Platform(PlatformError::InvalidDeviceResponse))
+        }
+    }
+}
+
+fn map_bytes(map: &CoseMap, label: i128) -> Result<&[u8], Error> {
+    match map.get(&Value::Integer(label)) {
+        Some(Value::Bytes(b)) => Ok(b.as_slice()),
+        Some(_) => {
+            warn!(label, "COSE_Key field is not a byte string");
+            Err(Error::Platform(PlatformError::InvalidDeviceResponse))
+        }
+        None => {
+            warn!(label, "COSE_Key missing required field");
+            Err(Error::Platform(PlatformError::InvalidDeviceResponse))
+        }
+    }
+}
+
+fn read_alg_from_map(map: &CoseMap) -> Result<Ctap2COSEAlgorithmIdentifier, Error> {
+    let alg_i128 = map_integer(map, COSE_KEY_LABEL_ALG)?;
+    let alg_i32 = i32::try_from(alg_i128).map_err(|_| {
+        warn!(alg = %alg_i128, "COSE_Key `alg` outside i32 range");
+        Error::Platform(PlatformError::InvalidDeviceResponse)
+    })?;
+    Ok(Ctap2COSEAlgorithmIdentifier(alg_i32))
+}
+
 /// Read the `alg` parameter from a COSE_Key encoded as CBOR bytes.
 ///
 /// Per WebAuthn L3 §6.5.2, every credential public key MUST include the
 /// `alg` parameter. A missing, non-integer, or out-of-range value is
 /// treated as an invalid device response.
 pub(crate) fn read_alg(bytes: &[u8]) -> Result<Ctap2COSEAlgorithmIdentifier, Error> {
-    let value: Value = serde_cbor_2::from_slice(bytes).map_err(|e| {
-        warn!(%e, "failed to parse COSE_Key as CBOR");
-        Error::Platform(PlatformError::InvalidDeviceResponse)
-    })?;
+    let map = parse_cose_map(bytes)?;
+    read_alg_from_map(&map)
+}
 
-    let Value::Map(map) = value else {
-        warn!("COSE_Key is not a CBOR map");
+/// Convert a COSE_Key to a DER-encoded `SubjectPublicKeyInfo`.
+///
+/// Returns:
+/// - `Ok(Some(der))` for an understood algorithm with a well-formed key.
+/// - `Ok(None)` when the algorithm is not in the supported set. This
+///   matches WebAuthn L3 §5.2.1.1 which lets `getPublicKey()` return null
+///   for algorithms the user agent does not implement.
+/// - `Err(_)` when the algorithm IS understood but the COSE_Key is
+///   malformed (missing fields, wrong shape, wrong curve, wrong sizes).
+///
+/// The supported set is the WebAuthn L3 floor (ES256, EdDSA, RS256) plus
+/// ESP256 from RFC 9864, which maps to the same SPKI as ES256.
+pub fn to_spki(bytes: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+    let map = parse_cose_map(bytes)?;
+    let alg = read_alg_from_map(&map)?;
+
+    match alg {
+        Ctap2COSEAlgorithmIdentifier::ES256 | Ctap2COSEAlgorithmIdentifier::ESP256 => {
+            require_kty(&map, COSE_KTY_EC2)?;
+            require_crv(&map, COSE_CRV_P256)?;
+            let x = map_bytes(&map, COSE_KEY_LABEL_X)?;
+            let y = map_bytes(&map, COSE_KEY_LABEL_Y)?;
+            Ok(Some(p256_spki(x, y)?))
+        }
+        Ctap2COSEAlgorithmIdentifier::EDDSA => {
+            require_kty(&map, COSE_KTY_OKP)?;
+            require_crv(&map, COSE_CRV_ED25519)?;
+            let x = map_bytes(&map, COSE_KEY_LABEL_X)?;
+            Ok(Some(ed25519_spki(x)?))
+        }
+        Ctap2COSEAlgorithmIdentifier::RS256 => {
+            require_kty(&map, COSE_KTY_RSA)?;
+            let n = map_bytes(&map, COSE_KEY_LABEL_N)?;
+            let e = map_bytes(&map, COSE_KEY_LABEL_E)?;
+            Ok(Some(rs256_spki(n, e)?))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn require_kty(map: &CoseMap, expected: i128) -> Result<(), Error> {
+    let kty = map_integer(map, COSE_KEY_LABEL_KTY)?;
+    if kty != expected {
+        warn!(expected, got = kty, "COSE_Key kty mismatch");
         return Err(Error::Platform(PlatformError::InvalidDeviceResponse));
+    }
+    Ok(())
+}
+
+fn require_crv(map: &CoseMap, expected: i128) -> Result<(), Error> {
+    let crv = map_integer(map, COSE_KEY_LABEL_CRV)?;
+    if crv != expected {
+        warn!(expected, got = crv, "COSE_Key crv mismatch");
+        return Err(Error::Platform(PlatformError::InvalidDeviceResponse));
+    }
+    Ok(())
+}
+
+fn p256_spki(x: &[u8], y: &[u8]) -> Result<Vec<u8>, Error> {
+    if x.len() != 32 || y.len() != 32 {
+        warn!(
+            x_len = x.len(),
+            y_len = y.len(),
+            "P-256 coordinates wrong size"
+        );
+        return Err(Error::Platform(PlatformError::InvalidDeviceResponse));
+    }
+    let mut point = Vec::with_capacity(65);
+    point.push(0x04); // uncompressed point indicator (SEC1)
+    point.extend_from_slice(x);
+    point.extend_from_slice(y);
+
+    let curve_oid_der = OID_SECP256R1
+        .to_der()
+        .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?;
+    let parameters = der::Any::from_der(&curve_oid_der)
+        .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?;
+
+    let spki = SubjectPublicKeyInfoOwned {
+        algorithm: AlgorithmIdentifierOwned {
+            oid: OID_EC_PUBLIC_KEY,
+            parameters: Some(parameters),
+        },
+        subject_public_key: BitString::from_bytes(&point)
+            .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?,
     };
 
-    let alg_value = map
-        .get(&Value::Integer(COSE_KEY_LABEL_ALG))
-        .ok_or_else(|| {
-            warn!("COSE_Key missing required `alg` parameter");
-            Error::Platform(PlatformError::InvalidDeviceResponse)
-        })?;
+    spki.to_der()
+        .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))
+}
 
-    let Value::Integer(alg) = alg_value else {
-        warn!("COSE_Key `alg` is not an integer");
+fn ed25519_spki(x: &[u8]) -> Result<Vec<u8>, Error> {
+    if x.len() != 32 {
+        warn!(len = x.len(), "Ed25519 public key wrong size");
         return Err(Error::Platform(PlatformError::InvalidDeviceResponse));
+    }
+
+    let spki = SubjectPublicKeyInfoOwned {
+        algorithm: AlgorithmIdentifierOwned {
+            oid: OID_ED25519,
+            parameters: None,
+        },
+        subject_public_key: BitString::from_bytes(x)
+            .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?,
     };
 
-    let alg_i32 = i32::try_from(*alg).map_err(|_| {
-        warn!(alg = %alg, "COSE_Key `alg` outside i32 range");
-        Error::Platform(PlatformError::InvalidDeviceResponse)
-    })?;
+    spki.to_der()
+        .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))
+}
 
-    Ok(Ctap2COSEAlgorithmIdentifier(alg_i32))
+#[derive(Sequence)]
+struct Pkcs1RsaPublicKey<'a> {
+    modulus: der::asn1::UintRef<'a>,
+    public_exponent: der::asn1::UintRef<'a>,
+}
+
+fn rs256_spki(n: &[u8], e: &[u8]) -> Result<Vec<u8>, Error> {
+    let inner = Pkcs1RsaPublicKey {
+        modulus: der::asn1::UintRef::new(n)
+            .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?,
+        public_exponent: der::asn1::UintRef::new(e)
+            .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?,
+    };
+    let inner_der = inner
+        .to_der()
+        .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?;
+
+    let null_der = Null
+        .to_der()
+        .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?;
+    let parameters = der::Any::from_der(&null_der)
+        .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?;
+
+    let spki = SubjectPublicKeyInfoOwned {
+        algorithm: AlgorithmIdentifierOwned {
+            oid: OID_RSA_ENCRYPTION,
+            parameters: Some(parameters),
+        },
+        subject_public_key: BitString::from_bytes(&inner_der)
+            .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))?,
+    };
+
+    spki.to_der()
+        .map_err(|_| Error::Platform(PlatformError::InvalidDeviceResponse))
 }
 
 #[cfg(test)]
@@ -185,5 +383,171 @@ mod tests {
     #[test]
     fn rejects_malformed_cbor() {
         assert!(read_alg(&[0xFF, 0xFF, 0xFF]).is_err());
+    }
+
+    fn cose_key_ed25519() -> Vec<u8> {
+        cbor::to_vec(&Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(COSE_KTY_OKP)),
+                (Value::Integer(3), Value::Integer(-8)),
+                (Value::Integer(-1), Value::Integer(COSE_CRV_ED25519)),
+                (Value::Integer(-2), Value::Bytes(vec![0x11; 32])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap()
+    }
+
+    fn cose_key_esp256() -> Vec<u8> {
+        cbor::to_vec(&Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(COSE_KTY_EC2)),
+                (Value::Integer(3), Value::Integer(-9)),
+                (Value::Integer(-1), Value::Integer(COSE_CRV_P256)),
+                (Value::Integer(-2), Value::Bytes(vec![0x22; 32])),
+                (Value::Integer(-3), Value::Bytes(vec![0x33; 32])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap()
+    }
+
+    /// Re-parse the SPKI we just emitted and check the algorithm and inner
+    /// key bytes match the input.
+    fn parse_spki(der: &[u8]) -> spki::SubjectPublicKeyInfo<der::Any, BitString> {
+        spki::SubjectPublicKeyInfo::from_der(der).unwrap()
+    }
+
+    #[test]
+    fn emits_es256_spki() {
+        let der = to_spki(&cose_key_es256()).unwrap().unwrap();
+        let spki = parse_spki(&der);
+        assert_eq!(spki.algorithm.oid, OID_EC_PUBLIC_KEY);
+        let params_oid: ObjectIdentifier = der::asn1::ObjectIdentifier::from_der(
+            &spki.algorithm.parameters.unwrap().to_der().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(params_oid, OID_SECP256R1);
+        // 0x04 || X(32) || Y(32) = 65 bytes
+        let key_bytes = spki.subject_public_key.raw_bytes();
+        assert_eq!(key_bytes.len(), 65);
+        assert_eq!(key_bytes[0], 0x04);
+        assert_eq!(&key_bytes[1..33], &[0xAA; 32]);
+        assert_eq!(&key_bytes[33..65], &[0xBB; 32]);
+    }
+
+    #[test]
+    fn emits_same_spki_for_esp256_as_es256() {
+        let es256_der = to_spki(&cose_key_es256()).unwrap().unwrap();
+        let esp256_der = to_spki(&cose_key_esp256()).unwrap().unwrap();
+        let es256_spki = parse_spki(&es256_der);
+        let esp256_spki = parse_spki(&esp256_der);
+        // Algorithm and parameter encoding are identical between ES256 and
+        // ESP256 SPKI (both id-ecPublicKey + secp256r1), so the only diff
+        // is the coordinate bytes themselves.
+        assert_eq!(es256_spki.algorithm.oid, esp256_spki.algorithm.oid);
+        assert_eq!(
+            es256_spki.algorithm.parameters.unwrap().to_der().unwrap(),
+            esp256_spki.algorithm.parameters.unwrap().to_der().unwrap()
+        );
+    }
+
+    #[test]
+    fn emits_ed25519_spki() {
+        let der = to_spki(&cose_key_ed25519()).unwrap().unwrap();
+        let spki = parse_spki(&der);
+        assert_eq!(spki.algorithm.oid, OID_ED25519);
+        assert!(spki.algorithm.parameters.is_none());
+        let key_bytes = spki.subject_public_key.raw_bytes();
+        assert_eq!(key_bytes.len(), 32);
+        assert_eq!(key_bytes, &[0x11; 32]);
+    }
+
+    #[test]
+    fn emits_rs256_spki() {
+        let der = to_spki(&cose_key_rs256()).unwrap().unwrap();
+        let spki = parse_spki(&der);
+        assert_eq!(spki.algorithm.oid, OID_RSA_ENCRYPTION);
+        let params = spki.algorithm.parameters.unwrap();
+        // RSA SPKI per PKCS#1 §A.1: parameters MUST be NULL.
+        Null::from_der(&params.to_der().unwrap()).unwrap();
+        // Inner BIT STRING is a SEQUENCE of two INTEGERs (modulus, e).
+        let inner = spki.subject_public_key.raw_bytes();
+        let parsed: Pkcs1RsaPublicKey = Pkcs1RsaPublicKey::from_der(inner).unwrap();
+        assert_eq!(parsed.modulus.as_bytes(), &[0xCC; 256]);
+        assert_eq!(parsed.public_exponent.as_bytes(), &[0x01, 0x00, 0x01]);
+    }
+
+    #[test]
+    fn returns_none_for_unknown_algorithm() {
+        let bytes = cose_key_synthetic_pqc();
+        assert!(matches!(to_spki(&bytes), Ok(None)));
+    }
+
+    #[test]
+    fn rejects_es256_with_wrong_curve() {
+        let bytes = cbor::to_vec(&Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(COSE_KTY_EC2)),
+                (Value::Integer(3), Value::Integer(-7)),
+                (Value::Integer(-1), Value::Integer(2)), // P-384, not P-256
+                (Value::Integer(-2), Value::Bytes(vec![0xAA; 48])),
+                (Value::Integer(-3), Value::Bytes(vec![0xBB; 48])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap();
+        assert!(to_spki(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_es256_with_short_coordinate() {
+        let bytes = cbor::to_vec(&Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(COSE_KTY_EC2)),
+                (Value::Integer(3), Value::Integer(-7)),
+                (Value::Integer(-1), Value::Integer(COSE_CRV_P256)),
+                (Value::Integer(-2), Value::Bytes(vec![0xAA; 16])), // short
+                (Value::Integer(-3), Value::Bytes(vec![0xBB; 32])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap();
+        assert!(to_spki(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_rs256_missing_modulus() {
+        let bytes = cbor::to_vec(&Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(COSE_KTY_RSA)),
+                (Value::Integer(3), Value::Integer(-257)),
+                (Value::Integer(-2), Value::Bytes(vec![0x01, 0x00, 0x01])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap();
+        assert!(to_spki(&bytes).is_err());
+    }
+
+    #[test]
+    fn rejects_eddsa_with_wrong_kty() {
+        let bytes = cbor::to_vec(&Value::Map(
+            [
+                (Value::Integer(1), Value::Integer(COSE_KTY_EC2)), // wrong
+                (Value::Integer(3), Value::Integer(-8)),
+                (Value::Integer(-1), Value::Integer(COSE_CRV_ED25519)),
+                (Value::Integer(-2), Value::Bytes(vec![0x11; 32])),
+            ]
+            .into_iter()
+            .collect(),
+        ))
+        .unwrap();
+        assert!(to_spki(&bytes).is_err());
     }
 }


### PR DESCRIPTION
WebAuthn L3 §5.2.1.1 says `AuthenticatorAttestationResponse.getPublicKey()` returns DER-encoded SubjectPublicKeyInfo for credentials using ES256, EdDSA Ed25519 and RS256, and null for any algorithm the user agent does not implement. libwebauthn was emitting raw COSE bytes there instead, which relying parties could not feed into `SubtleCrypto` or standard X.509 parsers.

A new converter produces SPKI for the WebAuthn L3 floor plus ESP256, which is equivalent to ES256 per RFC 9864. Algorithms outside the supported set return null per spec. Malformed keys for understood algorithms surface as an error.

The conversion uses the `spki` and `der` crates from RustCrypto, both already in the transitive dependency tree via `p256`, so no new external runtime crates land. Adding new algorithm support later is a small per-algorithm addition.

Stacked on top of #229.