### PR TITLE
feat(pin): add pcmr permission and rename ephemeral token source (1/5)

### DIFF
--- a/libwebauthn/src/proto/ctap2/model/client_pin.rs
+++ b/libwebauthn/src/proto/ctap2/model/client_pin.rs
@@ -189,6 +189,7 @@ bitflags! {
         const BIO_ENROLLMENT = 0x08;
         const LARGE_BLOB_WRITE = 0x10;
         const AUTHENTICATOR_CONFIGURATION = 0x20;
+        const PERSISTENT_CREDENTIAL_MANAGEMENT_READ_ONLY = 0x40;
     }
 }
 
@@ -248,4 +249,18 @@ pub struct Ctap2ClientPinResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(index = 0x05)]
     pub uv_retries: Option<u32>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::Ctap2AuthTokenPermissionRole;
+
+    #[test]
+    fn pcmr_permission_bit() {
+        let pcmr = Ctap2AuthTokenPermissionRole::PERSISTENT_CREDENTIAL_MANAGEMENT_READ_ONLY;
+        // CTAP 2.3-PS section 6.5.5.7: pcmr is 0x40.
+        assert_eq!(pcmr.bits(), 0x40);
+        // Disjoint from every other permission, so the existing subset test isolates it.
+        assert!(!pcmr.intersects(Ctap2AuthTokenPermissionRole::all().difference(pcmr)));
+    }
 }

--- a/libwebauthn/src/proto/ctap2/model/get_info.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_info.rs
@@ -188,6 +188,11 @@ impl Ctap2GetInfoResponse {
         self.option_enabled("credMgmt") || self.option_enabled("credentialMgmtPreview")
     }
 
+    /// CTAP 2.2+ persistent pinUvAuthToken for read-only credential management (pcmr).
+    pub fn supports_persistent_credential_management_read_only(&self) -> bool {
+        self.option_enabled("perCredMgmtRO")
+    }
+
     pub fn supports_bio_enrollment(&self) -> bool {
         if let Some(options) = &self.options {
             return options.get("bioEnroll").is_some()
@@ -316,6 +321,18 @@ mod test {
         assert!(!info.can_establish_shared_secret());
         assert_eq!(info.uv_operation(false), None);
         assert_eq!(info.uv_operation(true), None);
+    }
+
+    #[test]
+    fn per_cred_mgmt_ro_detection() {
+        assert!(
+            !Ctap2GetInfoResponse::default().supports_persistent_credential_management_read_only()
+        );
+        assert!(!create_info(&[]).supports_persistent_credential_management_read_only());
+        assert!(!create_info(&[("perCredMgmtRO", false)])
+            .supports_persistent_credential_management_read_only());
+        assert!(create_info(&[("perCredMgmtRO", true)])
+            .supports_persistent_credential_management_read_only());
     }
 
     #[test]

--- a/libwebauthn/src/webauthn.rs
+++ b/libwebauthn/src/webauthn.rs
@@ -47,7 +47,7 @@ macro_rules! handle_errors {
     ($channel: expr, $resp: expr, $uv_auth_used: expr, $timeout: expr) => {
         match $resp {
             Err(Error::Ctap(CtapError::PINAuthInvalid))
-                if $uv_auth_used == UsedPinUvAuthToken::FromStorage =>
+                if $uv_auth_used == UsedPinUvAuthToken::FromEphemeralStorage =>
             {
                 info!("PINAuthInvalid: Clearing auth token storage and trying again.");
                 $channel.clear_uv_auth_token_store();

--- a/libwebauthn/src/webauthn/pin_uv_auth_token.rs
+++ b/libwebauthn/src/webauthn/pin_uv_auth_token.rs
@@ -22,7 +22,7 @@ use crate::{PinNotSetUpdate, PinRequiredUpdate, UvUpdate};
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 
 pub(crate) enum UsedPinUvAuthToken {
-    FromStorage,
+    FromEphemeralStorage,
     NewlyCalculated(Ctap2UserVerificationOperation),
     LegacyUV,
     SharedSecretOnly,
@@ -84,7 +84,7 @@ where
         );
         if let Some(uv_auth_token) = channel.get_uv_auth_token(&token_identifier) {
             ctap2_request.calculate_and_set_uv_auth(uv_proto.as_ref(), uv_auth_token)?;
-            return Ok(UsedPinUvAuthToken::FromStorage);
+            return Ok(UsedPinUvAuthToken::FromEphemeralStorage);
         }
     }
 


### PR DESCRIPTION
Part 1 of 5 in a stack: **#231 (this)**, #232, #233, #234, #235

This stack adds support for persistent pinUvAuthTokens (the CTAP 2.2+ `pcmr` permission). A persistent token lets a credential manager list the passkeys on a security key without re-prompting for the PIN on every app launch or replug. It is read-only credential management only and cannot assert, create, update, or delete. Storage is supplied by the caller, and tokens are invalidated on PIN change or authenticator reset.

### This PR

Groundwork, with no behaviour change:
- Renames the internal ephemeral token-source marker to make room for a persistent one.
- Adds the `pcmr` permission value and the getInfo capability check used to detect persistent-token support.
