### PR TITLE
docs: document full API on docs.rs and guard the build in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,21 @@
+name: docs.rs build
+
+on: [push, pull_request]
+
+jobs:
+  docs:
+    name: docs.rs build
+    runs-on: ubuntu-latest
+    # Same image docs.rs uses, so missing system libraries surface here first.
+    container:
+      image: ghcr.io/rust-lang/crates-build-env/linux:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly --profile minimal
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Install cargo-docs-rs
+        run: cargo install --locked cargo-docs-rs
+      - name: Build docs the way docs.rs does
+        run: cargo +nightly docs-rs -p libwebauthn

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -19,6 +19,13 @@ resolver = "2"
 name = "libwebauthn"
 path = "src/lib.rs"
 
+# docs.rs builds with default features only, which omits the NFC transport.
+# Document it too. libnfc is not available in the docs.rs build environment, so
+# the libnfc backend is left out and NFC is documented through the pcsc backend.
+[package.metadata.docs.rs]
+features = ["nfc-backend-pcsc"]
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = []
 nfc = ["apdu-core", "apdu"]


### PR DESCRIPTION
docs.rs builds a crate with its default features only, which left the NFC transport out of the published documentation. This adds docs.rs metadata so the NFC transport is documented through the pcsc backend. libnfc is not available in the docs.rs build environment, so the libnfc backend is intentionally left out to keep the build green.

It also adds a CI job that builds the documentation the same way docs.rs does, inside the same container image. A broken docs build now fails a pull request instead of only showing up as a red badge after release.