### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "libwebauthn"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "aes",
  "apdu",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ _Looking for the D-Bus API proposal?_ Check out [credentialsd][credentialsd].
   - 🟢 Verify assertion
   - 🟢 Biometric user verification
   - 🟢 Discoverable credentials (resident keys)
+  - 🟢 Related origins (WebAuthn L3 §5.11)
 - FIDO2 to FIDO U2F downgrade
   - 🟢 Basic functionality
   - 🟢 Support for excludeList and pre-flight requests

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libwebauthn"
 description = "FIDO2 (WebAuthn) and FIDO U2F platform library for Linux written in Rust "
-version = "0.5.1"
+version = "0.6.0"
 authors = [
     "Alfie Fresta <afresta@noentropy.org>",
     "Martin Sirringhaus <martin.sirringhaus@suse.com>",


### PR DESCRIPTION
Release 0.6.0.

Highlights since 0.5.1:
- Related origins validation (WebAuthn L3 §5.11)
- `getPublicKey()` now emits SubjectPublicKeyInfo
- Credential public keys stored as opaque COSE bytes, with pass-through of arbitrary COSE algorithm identifiers