### PR TITLE
fix(webauthn): scope rp.id to the registrable domain under multi-label suffixes

### DIFF
--- a/libwebauthn/src/ops/webauthn/idl/origin.rs
+++ b/libwebauthn/src/ops/webauthn/idl/origin.rs
@@ -294,9 +294,9 @@ impl TryFrom<String> for RequestOrigin {
 /// is equal to") which WebAuthn L3 §5.1.3 step 7 / §5.1.7 step 9 reference.
 ///
 /// Public-suffix knowledge is supplied by the caller via the
-/// [`PublicSuffixList`] trait. Validation rejects bare public suffixes (e.g.
-/// `co.uk`) on either side of the comparison so they cannot be claimed as an
-/// rp.id.
+/// [`PublicSuffixList`] trait. Validation requires the effective domain's
+/// registrable domain to be a suffix of, or equal to, the rp.id, so bare
+/// public suffixes (e.g. `co.uk`) cannot be claimed as an rp.id.
 pub(crate) fn is_registrable_domain_suffix_or_equal(
     rp_id: &str,
     effective_domain: &str,
@@ -322,19 +322,19 @@ pub(crate) fn is_registrable_domain_suffix_or_equal(
         return false;
     }
 
-    // `rp_id` must not be `effective_domain`'s public suffix (otherwise an
-    // attacker on a sibling registrable could claim the eTLD).
-    if psl.public_suffix(effective_domain).as_deref() == Some(rp_id) {
+    // The effective domain's registrable domain must be a suffix of, or equal
+    // to, `rp_id`, so `rp_id` cannot sit above the registrable domain.
+    let Some(rd) = psl.registrable_domain(effective_domain) else {
+        return false;
+    };
+    if rp_id == rd {
+        return true;
+    }
+    if rp_id.len() <= rd.len() {
         return false;
     }
-
-    // `rp_id` must not itself be a public suffix (cannot register a credential
-    // against a bare eTLD like `co.uk`).
-    if psl.public_suffix(rp_id).as_deref() == Some(rp_id) {
-        return false;
-    }
-
-    true
+    let rd_boundary = rp_id.len() - rd.len() - 1;
+    rp_id.as_bytes().get(rd_boundary) == Some(&b'.') && rp_id[rd_boundary + 1..] == rd
 }
 
 #[cfg(test)]
@@ -667,10 +667,40 @@ mod tests {
     }
 
     #[test]
-    fn registrable_suffix_localhost_subdomain_accepted() {
-        assert!(is_registrable_domain_suffix_or_equal(
+    fn registrable_suffix_localhost_subdomain_rejected() {
+        // `localhost` is not a public suffix, so `sub.localhost` has no
+        // registrable domain and an rp.id above the full host is rejected.
+        assert!(!is_registrable_domain_suffix_or_equal(
             "localhost",
             "sub.localhost",
+            &psl(),
+        ));
+    }
+
+    #[test]
+    fn registrable_suffix_multilabel_private_suffix() {
+        // Under a multi-label private suffix the registrable domain is the
+        // full host, so an rp.id above it must be rejected.
+        let host = "app.svc.example.com";
+        assert!(!is_registrable_domain_suffix_or_equal(
+            "example.com",
+            host,
+            &psl(),
+        ));
+        assert!(is_registrable_domain_suffix_or_equal(host, host, &psl()));
+
+        // Single-label public suffix cases are unchanged.
+        let host = "login.example.com";
+        assert!(is_registrable_domain_suffix_or_equal(
+            "example.com",
+            host,
+            &psl(),
+        ));
+        assert!(is_registrable_domain_suffix_or_equal(host, host, &psl()));
+        assert!(!is_registrable_domain_suffix_or_equal("com", host, &psl()));
+        assert!(!is_registrable_domain_suffix_or_equal(
+            "m.login.example.com",
+            host,
             &psl(),
         ));
     }

--- a/libwebauthn/src/ops/webauthn/psl/mod.rs
+++ b/libwebauthn/src/ops/webauthn/psl/mod.rs
@@ -58,25 +58,22 @@ pub trait PublicSuffixList: Send + Sync {
 
 /// Test-only PSL that recognises a small fixed set of public suffixes.
 ///
-/// Sufficient for unit tests of the suffix-check algorithm without reading
-/// the system file. Recognises `com`, `co.uk`, `org`, and `net`.
+/// Sufficient for unit tests of the suffix-check algorithm without reading the
+/// system file. Recognises `com`, `co.uk`, `org`, `net`, and the multi-label
+/// private suffix `svc.example.com`, returning the longest match.
 #[cfg(test)]
 pub(crate) struct MockPublicSuffixList;
 
 #[cfg(test)]
 impl PublicSuffixList for MockPublicSuffixList {
     fn public_suffix(&self, host: &str) -> Option<String> {
-        const KNOWN_SUFFIXES: &[&str] = &["com", "co.uk", "org", "net"];
-        for suffix in KNOWN_SUFFIXES {
-            if host == *suffix {
-                return Some((*suffix).to_string());
-            }
-            let needle = format!(".{suffix}");
-            if host.ends_with(&needle) {
-                return Some((*suffix).to_string());
-            }
-        }
-        None
+        const KNOWN_SUFFIXES: &[&str] = &["com", "co.uk", "org", "net", "svc.example.com"];
+        KNOWN_SUFFIXES
+            .iter()
+            .copied()
+            .filter(|suffix| host == *suffix || host.ends_with(&format!(".{suffix}")))
+            .max_by_key(|suffix| suffix.len())
+            .map(str::to_string)
     }
 }
 


### PR DESCRIPTION
When a relying party ID is validated against the caller origin, the check approximated the registrable-domain rule with a public-suffix heuristic. That heuristic only holds for single-label effective top-level domains. Under a multi-label suffix it accepted relying party IDs that sit above the registrable domain, so a site hosted under a shared multi-label suffix could claim an ID spanning unrelated tenants.

This validates the relying party ID directly against the effective domain's registrable domain. The ID is accepted only when it equals the registrable domain or is a sub-domain of it.

Behavior change: a relying party ID of `localhost` is still accepted for an origin of `http://localhost`, but is now rejected for a sub-domain such as `sub.localhost`, which matches browser behavior.

Includes a regression test covering a multi-label suffix and the standard example.com cases.
