### PR TITLE
fix(ctap2): decode unsignedExtensionOutputs at GetAssertion 0x08

### DIFF
--- a/libwebauthn/src/ops/u2f.rs
+++ b/libwebauthn/src/ops/u2f.rs
@@ -216,8 +216,7 @@ impl UpgradableResponse<GetAssertionResponse, SignRequest> for SignResponse {
             credentials_count: None,
             user_selected: None,
             large_blob_key: None,
-            enterprise_attestation: None,
-            attestation_statement: None,
+            unsigned_extension_outputs: None,
         };
 
         // This isn't great, but we have no access to the original request, and need to construct

--- a/libwebauthn/src/ops/webauthn/get_assertion.rs
+++ b/libwebauthn/src/ops/webauthn/get_assertion.rs
@@ -25,8 +25,8 @@ use crate::{
     },
     pin::PinUvAuthProtocol,
     proto::ctap2::{
-        Ctap2AttestationStatement, Ctap2GetAssertionResponseExtensions,
-        Ctap2PublicKeyCredentialDescriptor, Ctap2PublicKeyCredentialUserEntity,
+        Ctap2GetAssertionResponseExtensions, Ctap2PublicKeyCredentialDescriptor,
+        Ctap2PublicKeyCredentialUserEntity,
     },
     webauthn::CtapError,
 };
@@ -452,8 +452,6 @@ pub struct Assertion {
     pub credentials_count: Option<u32>,
     pub user_selected: Option<bool>,
     pub unsigned_extensions_output: Option<GetAssertionResponseUnsignedExtensions>,
-    pub enterprise_attestation: Option<bool>,
-    pub attestation_statement: Option<Ctap2AttestationStatement>,
 }
 
 impl WebAuthnIDLResponse for Assertion {
@@ -1229,8 +1227,6 @@ mod tests {
             credentials_count: None,
             user_selected: None,
             unsigned_extensions_output: None,
-            enterprise_attestation: None,
-            attestation_statement: None,
         }
     }
 

--- a/libwebauthn/src/proto/ctap2/model/get_assertion.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_assertion.rs
@@ -370,11 +370,7 @@ pub struct Ctap2GetAssertionResponse {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(index = 0x08)]
-    pub enterprise_attestation: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(index = 0x09)]
-    pub attestation_statement: Option<Ctap2AttestationStatement>,
+    pub unsigned_extension_outputs: Option<BTreeMap<Value, Value>>,
 }
 
 impl Ctap2UserVerifiableRequest for Ctap2GetAssertionRequest {
@@ -462,8 +458,6 @@ impl Ctap2GetAssertionResponse {
             credentials_count: self.credentials_count,
             user_selected: self.user_selected,
             unsigned_extensions_output,
-            enterprise_attestation: self.enterprise_attestation,
-            attestation_statement: self.attestation_statement,
         }
     }
 }
@@ -575,8 +569,7 @@ mod tests {
             credentials_count: None,
             user_selected: None,
             large_blob_key: None,
-            enterprise_attestation: None,
-            attestation_statement: None,
+            unsigned_extension_outputs: None,
         }
     }
 
@@ -659,5 +652,29 @@ mod tests {
             .expect("largeBlob extension output present");
 
         assert!(large_blob.blob.is_none());
+    }
+
+    #[test]
+    fn decodes_unsigned_extension_outputs_at_index_0x08() {
+        // 0x08 is unsignedExtensionOutputs (a CBOR map), not enterprise attestation.
+        let mut auth_data = vec![0u8; 37];
+        auth_data[32] = AuthenticatorDataFlags::USER_PRESENT.bits();
+
+        let mut ueo = BTreeMap::new();
+        ueo.insert(
+            Value::Text("thirdPartyPayment".to_string()),
+            Value::Bool(true),
+        );
+
+        let mut response: BTreeMap<u64, Value> = BTreeMap::new();
+        response.insert(0x02, Value::Bytes(auth_data));
+        response.insert(0x03, Value::Bytes(vec![0xAAu8; 64]));
+        response.insert(0x08, Value::Map(ueo.clone()));
+
+        let bytes = crate::proto::ctap2::cbor::to_vec(&response).unwrap();
+        let parsed: Ctap2GetAssertionResponse =
+            crate::proto::ctap2::cbor::from_slice(&bytes).unwrap();
+
+        assert_eq!(parsed.unsigned_extension_outputs, Some(ueo));
     }
 }


### PR DESCRIPTION
The assertion response mapped entry 0x08 to a value it should not have, while the protocol defines 0x08 as the unsigned extension outputs map. An authenticator that returns that map caused the whole assertion response to fail to decode, breaking the ceremony. This becomes more likely as newer authenticators emit unsigned extension outputs.

This decodes entry 0x08 as the unsigned extension outputs map and removes two response fields that were never populated with valid data.

Scope: this fixes the decode failure. The unsigned outputs are kept on the decoded response but are not yet merged into the caller-facing extension results, since arbitrary CBOR maps do not map cleanly to the typed JSON outputs. That can be a follow-up. The change also drops two unused fields from the public assertion type, a minor change for a pre-1.0 crate.

Includes a regression test that decodes a response carrying the map and confirms it parses.
