### PR TITLE
fix(nfc): preserve APDU status words on the U2F path

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,5 +29,9 @@ jobs:
         run: cargo test --workspace --verbose
         env:
           LIBWEBAUTHN_PSL_SYSTEM_TEST: "1"
+      - name: Run tests with nfc-backend-pcsc
+        run: cargo test -p libwebauthn --lib --features nfc-backend-pcsc --verbose
+        env:
+          LIBWEBAUTHN_PSL_SYSTEM_TEST: "1"
       - name: Verify libwebauthn publishes cleanly
         run: cargo publish --dry-run -p libwebauthn

--- a/libwebauthn/src/proto/ctap1/apdu/response.rs
+++ b/libwebauthn/src/proto/ctap1/apdu/response.rs
@@ -16,6 +16,7 @@ pub struct ApduResponse {
 pub enum ApduResponseStatus {
     NoError = 0x9000,
     UserPresenceTestFailed = 0x6985,
+    CommandNotAllowed = 0x6986,
     InvalidKeyHandle = 0x6A80,
     InvalidRequestLength = 0x6700,
     InvalidClassByte = 0x6E00,

--- a/libwebauthn/src/proto/error.rs
+++ b/libwebauthn/src/proto/error.rs
@@ -84,6 +84,7 @@ impl From<ApduResponseStatus> for CtapError {
         match status {
             ApduResponseStatus::NoError => CtapError::Ok,
             ApduResponseStatus::UserPresenceTestFailed => CtapError::UserPresenceRequired,
+            ApduResponseStatus::CommandNotAllowed => CtapError::NotAllowed,
             ApduResponseStatus::InvalidKeyHandle => CtapError::NoCredentials,
             ApduResponseStatus::InvalidRequestLength => CtapError::InvalidLength,
             ApduResponseStatus::InvalidClassByte => CtapError::Other,

--- a/libwebauthn/src/transport/nfc/channel.rs
+++ b/libwebauthn/src/transport/nfc/channel.rs
@@ -194,7 +194,8 @@ where
         Ok(res)
     }
 
-    pub fn handle<'a>(
+    /// Returns the full response, payload plus SW1/SW2 trailer, without interpreting the status.
+    fn handle_raw<'a>(
         &'a mut self,
         ctx: Ctx,
         command: impl Into<Command<'a>>,
@@ -223,6 +224,15 @@ where
         }
 
         rapdu.extend_from_slice(&[sw1, sw2]);
+        Ok(rapdu)
+    }
+
+    pub fn handle<'a>(
+        &'a mut self,
+        ctx: Ctx,
+        command: impl Into<Command<'a>>,
+    ) -> Result<Vec<u8>, NfcError> {
+        let rapdu = self.handle_raw(ctx, command)?;
         Result::from(Response::from(rapdu.as_slice()))
             .map(|p| p.to_vec())
             .map_err(|e| {
@@ -259,10 +269,11 @@ where
 
     #[instrument(level = Level::DEBUG, skip_all)]
     async fn apdu_send(&mut self, request: &ApduRequest, _timeout: Duration) -> Result<(), Error> {
-        let resp = self.handle(self.ctx, request)?;
+        let resp = self.handle_raw(self.ctx, request)?;
         trace!("apdu_send {:?}", resp);
 
-        let apdu_response = ApduResponse::new_success(&resp);
+        let apdu_response = ApduResponse::try_from(&resp)
+            .or(Err(Error::Transport(TransportError::InvalidFraming)))?;
         self.apdu_response = Some(apdu_response);
         Ok(())
     }
@@ -360,7 +371,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::is_fido2_version;
+    use std::fmt::{Display, Formatter};
+    use std::time::Duration;
+
+    use super::{is_fido2_version, HandlerInCtx, NfcBackend, NfcChannel};
+    use crate::proto::ctap1::apdu::{ApduRequest, ApduResponseStatus};
+    use crate::proto::CtapError;
+    use crate::transport::channel::Channel;
 
     #[test]
     fn fido2_versions_are_recognised() {
@@ -385,5 +402,56 @@ mod tests {
         assert!(!is_fido2_version(b"FIDO_3_0"));
         assert!(!is_fido2_version(b"fido_2_0"));
         assert!(!is_fido2_version(b"FIDO_2_0\0"));
+    }
+
+    /// Backend that echoes a fixed APDU response regardless of the command.
+    struct FixedResponseBackend {
+        response: Vec<u8>,
+    }
+
+    impl Display for FixedResponseBackend {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FixedResponseBackend")
+        }
+    }
+
+    impl HandlerInCtx<u8> for FixedResponseBackend {
+        fn handle_in_ctx(
+            &mut self,
+            _ctx: u8,
+            _command: &[u8],
+            response: &mut [u8],
+        ) -> apdu_core::Result {
+            let n = self.response.len();
+            response[..n].copy_from_slice(&self.response);
+            Ok(n)
+        }
+    }
+
+    impl NfcBackend<u8> for FixedResponseBackend {}
+
+    #[tokio::test]
+    async fn u2f_wrong_data_status_word_is_preserved() {
+        // SW_WRONG_DATA (0x6A80) must surface as NoCredentials, not InvalidFraming.
+        let backend = FixedResponseBackend {
+            response: vec![0x6A, 0x80],
+        };
+        let mut channel = NfcChannel::new(Box::new(backend), 0u8);
+        let request = ApduRequest::new(0x02, 0x00, 0x00, None, None);
+
+        channel
+            .apdu_send(&request, Duration::from_secs(1))
+            .await
+            .expect("non-success SW must not collapse to InvalidFraming");
+        let response = channel.apdu_recv(Duration::from_secs(1)).await.unwrap();
+
+        assert_eq!(
+            response.status().unwrap(),
+            ApduResponseStatus::InvalidKeyHandle
+        );
+        assert_eq!(
+            CtapError::from(response.status().unwrap()),
+            CtapError::NoCredentials
+        );
     }
 }

--- a/libwebauthn/src/transport/nfc/channel.rs
+++ b/libwebauthn/src/transport/nfc/channel.rs
@@ -374,7 +374,7 @@ mod tests {
     use std::fmt::{Display, Formatter};
     use std::time::Duration;
 
-    use super::{is_fido2_version, HandlerInCtx, NfcBackend, NfcChannel};
+    use super::{is_fido2_version, ChannelSettings, HandlerInCtx, NfcBackend, NfcChannel};
     use crate::proto::ctap1::apdu::{ApduRequest, ApduResponseStatus};
     use crate::proto::CtapError;
     use crate::transport::channel::Channel;
@@ -436,7 +436,7 @@ mod tests {
         let backend = FixedResponseBackend {
             response: vec![0x6A, 0x80],
         };
-        let mut channel = NfcChannel::new(Box::new(backend), 0u8);
+        let mut channel = NfcChannel::new(Box::new(backend), 0u8, ChannelSettings::default());
         let request = ApduRequest::new(0x02, 0x00, 0x00, None, None);
 
         channel


### PR DESCRIPTION
On the U2F-over-NFC path the channel discarded the card status word and reported every non-success as a framing error. The U2F layer relies on the status word to tell whether a credential was absent, whether user presence is needed, or whether U2F is disabled, so authentication with several allowed credentials aborted on the first non-match.

This preserves the real status word so the U2F layer can interpret it, and reserves the framing error for genuinely malformed responses.

The NFC code only builds with an NFC backend feature enabled, so a separate commit adds a CI step that runs the NFC backend tests, ensuring the new guard is exercised.

Includes a regression test confirming a not-registered status is surfaced correctly.
