### PR TITLE
feat(webauthn): surface getAssertion unsignedExtensionOutputs to client extension results

### DIFF
--- a/libwebauthn/src/ops/webauthn/get_assertion.rs
+++ b/libwebauthn/src/ops/webauthn/get_assertion.rs
@@ -456,6 +456,13 @@ pub struct GetAssertionResponseUnsignedExtensions {
     /// if the extension wasn't requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub appid: Option<bool>,
+
+    /// Outputs of extensions the authenticator returns unsigned (getAssertion
+    /// response member 0x08), keyed by extension identifier and already
+    /// converted to JSON-safe values. Surfaced verbatim as top-level members of
+    /// the client extension results.
+    #[serde(flatten)]
+    pub unsigned_extension_outputs: serde_json::Map<String, serde_json::Value>,
 }
 
 /// Context required for serializing a GetAssertion response to JSON.
@@ -567,6 +574,25 @@ impl Assertion {
                             .map(|s| Base64UrlString::from(s.as_slice())),
                     }),
                 });
+            }
+
+            // Unsigned extension outputs (getAssertion 0x08): surface each entry
+            // as a top-level member, skipping ids that collide with a typed
+            // member to avoid emitting a duplicate JSON key.
+            const TYPED_MEMBERS: [&str; 6] = [
+                "appid",
+                "credProps",
+                "hmacCreateSecret",
+                "hmacGetSecret",
+                "largeBlob",
+                "prf",
+            ];
+            for (id, value) in &unsigned_ext.unsigned_extension_outputs {
+                if !TYPED_MEMBERS.contains(&id.as_str()) {
+                    results
+                        .unsigned_extension_outputs
+                        .insert(id.clone(), value.clone());
+                }
             }
         }
 
@@ -1351,6 +1377,7 @@ mod tests {
                 }),
             }),
             appid: None,
+            unsigned_extension_outputs: Default::default(),
         });
 
         let request = create_test_request();
@@ -1372,6 +1399,7 @@ mod tests {
             large_blob: None,
             prf: None,
             appid: Some(true),
+            unsigned_extension_outputs: Default::default(),
         });
 
         let request = create_test_request();
@@ -1395,6 +1423,7 @@ mod tests {
             large_blob: None,
             prf: None,
             appid: None,
+            unsigned_extension_outputs: Default::default(),
         });
 
         let request = create_test_request();

--- a/libwebauthn/src/ops/webauthn/idl/response.rs
+++ b/libwebauthn/src/ops/webauthn/idl/response.rs
@@ -225,6 +225,12 @@ pub struct AuthenticationExtensionsClientOutputsJSON {
     /// PRF extension output.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prf: Option<PRFOutputJSON>,
+
+    /// Outputs of extensions the authenticator returned unsigned (e.g.
+    /// `thirdPartyPayment`), each surfaced as a top-level member keyed by its
+    /// extension identifier. An empty map emits nothing.
+    #[serde(flatten)]
+    pub unsigned_extension_outputs: serde_json::Map<String, serde_json::Value>,
 }
 
 /// Credential properties extension output.

--- a/libwebauthn/src/proto/ctap2/cbor/json.rs
+++ b/libwebauthn/src/proto/ctap2/cbor/json.rs
@@ -1,0 +1,133 @@
+//! JSON-safe conversion of arbitrary CBOR values.
+//!
+//! Used to surface authenticator-provided maps that have no typed model, such
+//! as the getAssertion `unsignedExtensionOutputs` map (response member 0x08),
+//! into WebAuthn client extension results. Per the WebAuthn JSON convention,
+//! binary (CBOR byte string) values are encoded as base64url.
+
+use std::collections::BTreeMap;
+
+use serde_json::{Map, Number, Value as Json};
+
+use super::Value;
+
+/// Converts a CBOR map into a JSON object, dropping entries whose key cannot be
+/// represented as a JSON string.
+pub(crate) fn map_to_json_object(map: &BTreeMap<Value, Value>) -> Map<String, Json> {
+    map.iter()
+        .filter_map(|(k, v)| key_to_string(k).map(|k| (k, value_to_json(v))))
+        .collect()
+}
+
+/// Converts an arbitrary CBOR value into a JSON-safe value.
+fn value_to_json(value: &Value) -> Json {
+    match value {
+        Value::Null => Json::Null,
+        Value::Bool(b) => Json::Bool(*b),
+        Value::Integer(i) => integer_to_json(*i),
+        Value::Float(f) => Number::from_f64(*f).map(Json::Number).unwrap_or(Json::Null),
+        Value::Bytes(b) => Json::String(base64_url::encode(b)),
+        Value::Text(s) => Json::String(s.clone()),
+        Value::Array(items) => Json::Array(items.iter().map(value_to_json).collect()),
+        Value::Map(m) => Json::Object(map_to_json_object(m)),
+        // Tags carry no WebAuthn meaning here; surface the tagged value itself.
+        Value::Tag(_, inner) => value_to_json(inner),
+        // Non-exhaustive enum: anything else has no JSON representation.
+        _ => Json::Null,
+    }
+}
+
+/// CBOR integers span -2^64..2^64-1, wider than any single JSON number type.
+/// Map what fits into `i64`/`u64`; fall back to a decimal string otherwise.
+fn integer_to_json(i: i128) -> Json {
+    if let Ok(n) = i64::try_from(i) {
+        Json::Number(n.into())
+    } else if let Ok(n) = u64::try_from(i) {
+        Json::Number(n.into())
+    } else {
+        Json::String(i.to_string())
+    }
+}
+
+/// JSON object keys must be strings. Extension output maps use text keys; other
+/// scalar key types are stringified best-effort, and unsupported keys are
+/// dropped by the caller.
+fn key_to_string(key: &Value) -> Option<String> {
+    match key {
+        Value::Text(s) => Some(s.clone()),
+        Value::Integer(i) => Some(i.to_string()),
+        Value::Bytes(b) => Some(base64_url::encode(b)),
+        Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scalars_round_trip() {
+        assert_eq!(value_to_json(&Value::Bool(true)), Json::Bool(true));
+        assert_eq!(value_to_json(&Value::Null), Json::Null);
+        assert_eq!(value_to_json(&Value::Text("hi".into())), Json::from("hi"));
+        assert_eq!(value_to_json(&Value::Integer(42)), Json::from(42));
+        assert_eq!(value_to_json(&Value::Integer(-7)), Json::from(-7));
+    }
+
+    #[test]
+    fn bytes_become_base64url() {
+        let value = Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        assert_eq!(
+            value_to_json(&value),
+            Json::from(base64_url::encode(&[0xDE, 0xAD, 0xBE, 0xEF]))
+        );
+    }
+
+    #[test]
+    fn nested_array_and_map() {
+        let mut inner = BTreeMap::new();
+        inner.insert(Value::Text("blob".into()), Value::Bytes(vec![0x01, 0x02]));
+        let value = Value::Array(vec![Value::Integer(1), Value::Map(inner)]);
+
+        let json = value_to_json(&value);
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr[0], Json::from(1));
+        assert_eq!(
+            arr[1]["blob"],
+            Json::from(base64_url::encode(&[0x01, 0x02]))
+        );
+    }
+
+    #[test]
+    fn tag_surfaces_inner_value() {
+        let value = Value::Tag(42, Box::new(Value::Text("tagged".into())));
+        assert_eq!(value_to_json(&value), Json::from("tagged"));
+    }
+
+    #[test]
+    fn out_of_range_integer_becomes_string() {
+        let big = i128::from(u64::MAX) + 1;
+        assert_eq!(
+            value_to_json(&Value::Integer(big)),
+            Json::from(big.to_string())
+        );
+    }
+
+    #[test]
+    fn non_finite_float_becomes_null() {
+        assert_eq!(value_to_json(&Value::Float(f64::NAN)), Json::Null);
+        assert_eq!(value_to_json(&Value::Float(1.5)), Json::from(1.5));
+    }
+
+    #[test]
+    fn non_string_keys_are_dropped() {
+        let mut map = BTreeMap::new();
+        map.insert(Value::Text("ok".into()), Value::Bool(true));
+        map.insert(Value::Array(vec![Value::Integer(1)]), Value::Bool(false));
+
+        let object = map_to_json_object(&map);
+        assert_eq!(object.len(), 1);
+        assert_eq!(object["ok"], Json::Bool(true));
+    }
+}

--- a/libwebauthn/src/proto/ctap2/cbor/mod.rs
+++ b/libwebauthn/src/proto/ctap2/cbor/mod.rs
@@ -1,7 +1,9 @@
+mod json;
 mod request;
 mod response;
 mod serde;
 
+pub(crate) use json::map_to_json_object;
 pub use request::CborRequest;
 pub use response::CborResponse;
 pub(crate) use serde::{from_cursor, from_slice, to_vec, CborError, Value};

--- a/libwebauthn/src/proto/ctap2/model/get_assertion.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_assertion.rs
@@ -7,7 +7,7 @@ use crate::{
         GetAssertionResponseUnsignedExtensions, HMACGetSecretInput, PrfInputValue, PrfOutputValue,
     },
     pin::PinUvAuthProtocol,
-    proto::ctap2::cbor::Value,
+    proto::ctap2::cbor::{map_to_json_object, Value},
     transport::AuthTokenData,
     webauthn::{Error, PlatformError},
 };
@@ -466,11 +466,24 @@ impl Ctap2GetAssertionResponse {
         request: &GetAssertionRequest,
         auth_data: Option<&AuthTokenData>,
     ) -> Assertion {
-        let unsigned_extensions_output = self
+        let mut unsigned_extensions_output = self
             .authenticator_data
             .extensions
             .as_ref()
-            .map(|x| x.to_unsigned_extensions(request, &self, auth_data));
+            .map(|x| x.to_unsigned_extensions(request, auth_data));
+
+        // unsignedExtensionOutputs (response 0x08) are independent of the signed
+        // authenticator-data extensions, so surface them even when no signed
+        // extensions are present. CTAP 2.2: an empty map equals an omitted field.
+        if let Some(map) = &self.unsigned_extension_outputs {
+            let object = map_to_json_object(map);
+            if !object.is_empty() {
+                unsigned_extensions_output
+                    .get_or_insert_with(Default::default)
+                    .unsigned_extension_outputs = object;
+            }
+        }
+
         // CTAP2 6.2.2: authenticators may omit credential ID when the allow list has one entry.
         // We always return it, for convenience.
         let credential_id = self.credential_id.or_else(|| {
@@ -512,7 +525,6 @@ impl Ctap2GetAssertionResponseExtensions {
     pub(crate) fn to_unsigned_extensions(
         &self,
         request: &GetAssertionRequest,
-        _response: &Ctap2GetAssertionResponse,
         auth_data: Option<&AuthTokenData>,
     ) -> GetAssertionResponseUnsignedExtensions {
         let decrypted_hmac = self.hmac_secret.as_ref().and_then(|x| {
@@ -566,6 +578,7 @@ impl Ctap2GetAssertionResponseExtensions {
             large_blob,
             prf,
             appid,
+            unsigned_extension_outputs: Default::default(),
         }
     }
 }
@@ -710,5 +723,50 @@ mod tests {
             crate::proto::ctap2::cbor::from_slice(&bytes).unwrap();
 
         assert_eq!(parsed.unsigned_extension_outputs, Some(ueo));
+    }
+
+    #[test]
+    fn surfaces_unsigned_extension_outputs_in_client_extension_results() {
+        use crate::ops::webauthn::idl::response::{JsonFormat, WebAuthnIDLResponse};
+
+        // End-to-end: a getAssertion response carrying unsignedExtensionOutputs
+        // (0x08) with a boolean (thirdPartyPayment) and a byte string is decoded
+        // and surfaced into the client extension results JSON, with bytes encoded
+        // as base64url.
+        let mut auth_data = vec![0u8; 37];
+        auth_data[32] = AuthenticatorDataFlags::USER_PRESENT.bits();
+
+        let mut ueo = BTreeMap::new();
+        ueo.insert(
+            Value::Text("thirdPartyPayment".to_string()),
+            Value::Bool(true),
+        );
+        ueo.insert(
+            Value::Text("blobby".to_string()),
+            Value::Bytes(vec![0xDE, 0xAD, 0xBE, 0xEF]),
+        );
+
+        let mut response: BTreeMap<u64, Value> = BTreeMap::new();
+        response.insert(0x02, Value::Bytes(auth_data));
+        response.insert(0x03, Value::Bytes(vec![0xAAu8; 64]));
+        response.insert(0x08, Value::Map(ueo));
+
+        let bytes = crate::proto::ctap2::cbor::to_vec(&response).unwrap();
+        let parsed: Ctap2GetAssertionResponse =
+            crate::proto::ctap2::cbor::from_slice(&bytes).unwrap();
+
+        let request = make_request(vec![make_credential(b"cred-1")]);
+        let assertion = parsed.into_assertion_output(&request, None);
+        let json_str = assertion
+            .to_json_string(&request, JsonFormat::default())
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        let results = &json["clientExtensionResults"];
+        assert_eq!(results["thirdPartyPayment"], serde_json::json!(true));
+        assert_eq!(
+            results["blobby"],
+            serde_json::json!(base64_url::encode(&[0xDE, 0xAD, 0xBE, 0xEF]))
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #244.

That change fixed decoding of the unsigned extension outputs returned at the getAssertion response, but stopped short of surfacing them to callers. The decoded map stayed on the protocol response and never reached the client extension results.

This surfaces those outputs. Because the map has no fixed schema, each entry is converted to a JSON-safe value and exposed as a top-level member of the client extension results, keyed by its extension identifier. That matches how WebAuthn structures client extension results, so an output such as thirdPartyPayment sits alongside the existing typed outputs. Binary values are encoded as base64url to stay consistent with the rest of the JSON output. An empty or absent map adds nothing.

Closes #250.