### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "libwebauthn"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libwebauthn"
 description = "FIDO2 (WebAuthn) and FIDO U2F platform library for Linux written in Rust "
-version = "0.6.0"
+version = "0.7.0"
 authors = [
     "Alfie Fresta <afresta@noentropy.org>",
     "Martin Sirringhaus <martin.sirringhaus@suse.com>",


### PR DESCRIPTION
Release 0.7.0.

What's in this release since 0.6.0:
- largeBlob extension: read, write, and delete
- Persistent pinUvAuthToken support for credential management
- CTAP2/WebAuthn conformance fixes: canonical CBOR ordering, clientDataJSON field order, registrable-domain rp.id scoping, raw authenticatorData preservation
- NFC and U2F robustness fixes
