### PR TITLE
fix(ctap2): do not send uv option together with pinUvAuthParam

### DIFF
--- a/libwebauthn/src/proto/ctap2/model/get_assertion.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_assertion.rs
@@ -692,6 +692,37 @@ mod tests {
     }
 
     #[test]
+    fn pin_uv_auth_param_clears_uv_option() {
+        use crate::ops::webauthn::UserVerificationRequirement;
+        use crate::pin::PinUvAuthProtocolOne;
+
+        let mut request = make_request(vec![]);
+        request.user_verification = UserVerificationRequirement::Required;
+        let mut ctap2 = Ctap2GetAssertionRequest::from(request);
+        assert!(ctap2.options.unwrap().require_user_verification);
+
+        let proto = PinUvAuthProtocolOne::new();
+        ctap2
+            .calculate_and_set_uv_auth(&proto, &[0xAA; 32])
+            .unwrap();
+
+        assert!(ctap2.pin_auth_param.is_some());
+        assert!(!ctap2.options.unwrap().require_user_verification);
+
+        // Wire check: the options map (0x05) must not contain "uv".
+        let bytes = crate::proto::ctap2::cbor::to_vec(&ctap2).unwrap();
+        let parsed: BTreeMap<u64, Value> = crate::proto::ctap2::cbor::from_slice(&bytes).unwrap();
+        let Some(Value::Map(options)) = parsed.get(&0x05) else {
+            panic!("options map missing from serialized request");
+        };
+        assert!(!options.contains_key(&Value::Text("uv".to_string())));
+        assert_eq!(
+            options.get(&Value::Text("up".to_string())),
+            Some(&Value::Bool(true))
+        );
+    }
+
+    #[test]
     fn decodes_unsigned_extension_outputs_at_index_0x08() {
         // 0x08 is unsignedExtensionOutputs (a CBOR map), not enterprise attestation.
         let mut auth_data = vec![0u8; 37];

--- a/libwebauthn/src/proto/ctap2/model/get_assertion.rs
+++ b/libwebauthn/src/proto/ctap2/model/get_assertion.rs
@@ -405,6 +405,9 @@ impl Ctap2UserVerifiableRequest for Ctap2GetAssertionRequest {
         let uv_auth_param = uv_proto.authenticate(uv_auth_token, hash)?;
         self.pin_auth_proto = Some(uv_proto.version() as u32);
         self.pin_auth_param = Some(ByteBuf::from(uv_auth_param));
+        if let Some(ref mut options) = self.options {
+            options.require_user_verification = false;
+        }
         Ok(())
     }
 

--- a/libwebauthn/src/proto/ctap2/model/make_credential.rs
+++ b/libwebauthn/src/proto/ctap2/model/make_credential.rs
@@ -389,6 +389,9 @@ impl Ctap2UserVerifiableRequest for Ctap2MakeCredentialRequest {
         let uv_auth_param = uv_proto.authenticate(uv_auth_token, hash)?;
         self.pin_auth_proto = Some(uv_proto.version() as u32);
         self.pin_auth_param = Some(ByteBuf::from(uv_auth_param));
+        if let Some(ref mut options) = self.options {
+            options.deprecated_require_user_verification = None;
+        }
         Ok(())
     }
 

--- a/libwebauthn/src/proto/ctap2/model/make_credential.rs
+++ b/libwebauthn/src/proto/ctap2/model/make_credential.rs
@@ -702,6 +702,33 @@ mod tests {
     }
 
     #[test]
+    fn pin_uv_auth_param_clears_deprecated_uv_option() {
+        use crate::pin::PinUvAuthProtocolOne;
+
+        let info = Ctap2GetInfoResponse::default();
+        let req = mc_request_with_prf(None);
+        let mut ctap2 = Ctap2MakeCredentialRequest::from_webauthn_request(&req, &info).unwrap();
+
+        ctap2.ensure_uv_set();
+        assert_eq!(
+            ctap2.options.unwrap().deprecated_require_user_verification,
+            Some(true)
+        );
+
+        let proto = PinUvAuthProtocolOne::new();
+        ctap2
+            .calculate_and_set_uv_auth(&proto, &[0xAA; 32])
+            .unwrap();
+
+        assert!(ctap2.pin_auth_param.is_some());
+        assert!(ctap2
+            .options
+            .unwrap()
+            .deprecated_require_user_verification
+            .is_none());
+    }
+
+    #[test]
     fn from_signed_extensions_decrypts_results_with_auth_data() {
         use crate::proto::ctap2::Ctap2UserVerificationOperation;
         use cosey::{Bytes, PublicKey};


### PR DESCRIPTION
This was tested with libwebauthn 0.5.1 in credentialsd master branch ([7c13749](https://github.com/linux-credentials/credentialsd/commit/7c137495b0fe1651171cc21a830feb0bfb7ff69c)) in a modified Teams for linux (FIDO2 passkey login login).
Token2 version 3.1 logins without problems.
Yubikey triggers `Ctap(InvalidOption)` error right after a PIN has been entered.

The FIDO 2.1 spec.`§6.1.2. authenticatorMakeCredential` and `§6.2.2. authenticatorGetAssertion` says "If the [pinUvAuthParam](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#getassert-pinuvauthparam) is present, let the "[uv](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#getassert-uv)" [option](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#getassert-option-key) be treated as being present with the value false."
So having UV=true and pinUvAuthParam will cause errors on a strict key like Yubikey.