### PR TITLE
fix(webauthn): accept PRF evalByCredential JSON key

### DIFF
--- a/libwebauthn/src/ops/webauthn/get_assertion.rs
+++ b/libwebauthn/src/ops/webauthn/get_assertion.rs
@@ -1246,13 +1246,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_prf_eval_by_credential_variable_length() {
-        // NOTE: the IDL field is currently deserialized as `eval_by_credential`
-        // rather than the spec name `evalByCredential` — separate concern from
-        // #209. Use the field name the deserializer accepts.
-        let prf = parse_prf(
-            r#"{"prf":{"eval_by_credential":{"Y3JlZDE":{"first":"AQ","second":"AgIC"}}}}"#,
-        )
-        .await;
+        let prf =
+            parse_prf(r#"{"prf":{"evalByCredential":{"Y3JlZDE":{"first":"AQ","second":"AgIC"}}}}"#)
+                .await;
         let v = prf.eval_by_credential.get("Y3JlZDE").expect("entry");
         assert_eq!(v.first, vec![0x01]);
         assert_eq!(v.second.as_deref(), Some(&[0x02u8, 0x02, 0x02][..]));

--- a/libwebauthn/src/ops/webauthn/idl/get.rs
+++ b/libwebauthn/src/ops/webauthn/idl/get.rs
@@ -67,6 +67,7 @@ pub struct LargeBlobInputJson {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PrfInputJson {
     pub eval: Option<PrfValuesJson>,
     pub eval_by_credential: Option<HashMap<String, PrfValuesJson>>,


### PR DESCRIPTION
JSON callers scope PRF salts per credential under the member name evalByCredential, but the deserializer only accepted a snake_case key, so the per-credential map was dropped before it could be used. This accepts the spec member name so those salts reach the assertion request.

Closes #251.
