### PR TITLE
fix(webauthn): default rp.id to effective domain and reject ip-literal rp ids

### DIFF
--- a/libwebauthn/src/ops/webauthn/get_assertion.rs
+++ b/libwebauthn/src/ops/webauthn/get_assertion.rs
@@ -192,7 +192,9 @@ impl FromIdlModel<PublicKeyCredentialRequestOptionsJSON> for GetAssertionRequest
             }
             parsed.0
         } else {
-            effective_rp_id.to_string()
+            RelyingPartyId::try_from(effective_rp_id)
+                .map_err(|err| GetAssertionPrepareError::InvalidRelyingPartyId(err.to_string()))?
+                .0
         };
 
         let prf = match inner.extensions.as_ref() {
@@ -892,6 +894,42 @@ mod tests {
     async fn test_request_from_json_invalid_rp_id() {
         let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_add(REQUEST_BASE_JSON, "rpId", r#""example.org.""#);
+
+        let result = from_json(
+            &request_origin,
+            &MockPublicSuffixList,
+            RelatedOrigins::Disabled,
+            &req_json,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(GetAssertionPrepareError::InvalidRelyingPartyId(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_request_from_json_rejects_ip_effective_domain() {
+        let request_origin: RequestOrigin = "https://127.0.0.1:8443".parse().unwrap();
+        let req_json = json_field_rm(REQUEST_BASE_JSON, "rpId");
+
+        let result = from_json(
+            &request_origin,
+            &MockPublicSuffixList,
+            RelatedOrigins::Disabled,
+            &req_json,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(GetAssertionPrepareError::InvalidRelyingPartyId(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_request_from_json_rejects_ipv6_effective_domain() {
+        let request_origin: RequestOrigin = "https://[::1]:8443".parse().unwrap();
+        let req_json = json_field_rm(REQUEST_BASE_JSON, "rpId");
 
         let result = from_json(
             &request_origin,

--- a/libwebauthn/src/ops/webauthn/idl/create.rs
+++ b/libwebauthn/src/ops/webauthn/idl/create.rs
@@ -4,7 +4,7 @@ use crate::{
     ops::webauthn::{
         MakeCredentialsRequestExtensions, ResidentKeyRequirement, UserVerificationRequirement,
     },
-    proto::ctap2::{Ctap2CredentialType, Ctap2PublicKeyCredentialRpEntity},
+    proto::ctap2::Ctap2CredentialType,
 };
 
 use serde::Deserialize;
@@ -28,6 +28,13 @@ fn default_user_verification() -> UserVerificationRequirement {
     UserVerificationRequirement::Preferred
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublicKeyCredentialRpEntityJSON {
+    pub id: Option<String>,
+    pub name: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicKeyCredentialUserEntity {
@@ -39,7 +46,7 @@ pub struct PublicKeyCredentialUserEntity {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicKeyCredentialCreationOptionsJSON {
-    pub rp: Ctap2PublicKeyCredentialRpEntity,
+    pub rp: PublicKeyCredentialRpEntityJSON,
     pub user: PublicKeyCredentialUserEntity,
     pub challenge: Base64UrlString,
     #[serde(rename = "pubKeyCredParams")]

--- a/libwebauthn/src/ops/webauthn/make_credential.rs
+++ b/libwebauthn/src/ops/webauthn/make_credential.rs
@@ -409,7 +409,7 @@ impl FromIdlModel<PublicKeyCredentialCreationOptionsJSON> for MakeCredentialRequ
         inner: PublicKeyCredentialCreationOptionsJSON,
     ) -> Result<Self, MakeCredentialPrepareError> {
         let effective_rp_id = request_origin.origin.host.as_str();
-        let rp_id = RelyingPartyId::try_from(inner.rp.id.as_str())
+        let rp_id = RelyingPartyId::try_from(inner.rp.id.as_deref().unwrap_or(effective_rp_id))
             .map_err(|err| MakeCredentialPrepareError::InvalidRelyingPartyId(err.to_string()))?;
         if !rp_id_authorised(request_origin, &rp_id, settings).await {
             return Err(MakeCredentialPrepareError::MismatchingRelyingPartyId(
@@ -417,8 +417,10 @@ impl FromIdlModel<PublicKeyCredentialCreationOptionsJSON> for MakeCredentialRequ
                 effective_rp_id.to_string(),
             ));
         }
-        let mut relying_party = inner.rp;
-        relying_party.id = rp_id.0;
+        let relying_party = Ctap2PublicKeyCredentialRpEntity {
+            id: rp_id.0,
+            name: inner.rp.name,
+        };
         let resident_key = if inner
             .authenticator_selection
             .as_ref()
@@ -1124,6 +1126,58 @@ mod tests {
             "rp",
             r#"{"id": "example.org.", "name": "example.org"}"#,
         );
+
+        let result = from_json(
+            &request_origin,
+            &MockPublicSuffixList,
+            RelatedOrigins::Disabled,
+            &req_json,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(MakeCredentialPrepareError::InvalidRelyingPartyId(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_request_from_json_rp_id_defaults_to_effective_domain() {
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
+        let req_json = json_field_add(REQUEST_BASE_JSON, "rp", r#"{"name": "example.org"}"#);
+
+        let req = from_json(
+            &request_origin,
+            &MockPublicSuffixList,
+            RelatedOrigins::Disabled,
+            &req_json,
+        )
+        .await
+        .unwrap();
+        assert_eq!(req.relying_party.id, "example.org");
+    }
+
+    #[tokio::test]
+    async fn test_request_from_json_rejects_ipv4_effective_domain() {
+        let request_origin: RequestOrigin = "https://127.0.0.1:8443".parse().unwrap();
+        let req_json = json_field_add(REQUEST_BASE_JSON, "rp", r#"{"name": "example.org"}"#);
+
+        let result = from_json(
+            &request_origin,
+            &MockPublicSuffixList,
+            RelatedOrigins::Disabled,
+            &req_json,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(MakeCredentialPrepareError::InvalidRelyingPartyId(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_request_from_json_rejects_ipv6_effective_domain() {
+        let request_origin: RequestOrigin = "https://[::1]:8443".parse().unwrap();
+        let req_json = json_field_add(REQUEST_BASE_JSON, "rp", r#"{"name": "example.org"}"#);
 
         let result = from_json(
             &request_origin,


### PR DESCRIPTION
Registration now defaults a missing RP ID to the caller effective domain, matching the assertion ceremony and the spec, instead of failing. Origins whose host is an IP address are rejected rather than used as an RP ID. This removes an inconsistency between the create and get paths and closes a malformed RP ID case.