### PR TITLE
fix(ctap2): preserve unknown ctap status codes and add 0x17/0x18

### DIFF
--- a/libwebauthn-tests/src/virt/mod.rs
+++ b/libwebauthn-tests/src/virt/mod.rs
@@ -5,10 +5,8 @@ use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 use std::thread::JoinHandle;
 
-use libwebauthn::proto::CtapError;
 use libwebauthn::transport::hid::framing::{HidCommand, HidMessage};
 use libwebauthn::transport::hid::{virtual_device, HidDevice, HidPipeBackend};
-use num_enum::TryFromPrimitive;
 
 /// `HidPipeBackend` implementation backed by an in-process trussed-staging
 /// fido-authenticator. Each instance owns a worker thread that owns the
@@ -75,18 +73,14 @@ impl TrussedVirtBackend {
                         }
                         Err(ctaphid::error::Error::CommandError(
                             ctaphid::error::CommandError::CborError(value),
-                        )) => match CtapError::try_from_primitive(value) {
-                            Ok(_) => {
-                                // Known CTAP error code: forward as a successful
-                                // transmission with the status byte as payload.
-                                let mut response = msg.clone();
-                                response.payload = vec![value];
-                                if resp_tx.send(response).is_err() {
-                                    break;
-                                }
+                        )) => {
+                            // Forward the status byte as a successful transmission.
+                            let mut response = msg.clone();
+                            response.payload = vec![value];
+                            if resp_tx.send(response).is_err() {
+                                break;
                             }
-                            Err(_) => panic!("Failed to parse CtapError from {value}"),
-                        },
+                        }
                         Err(err) => panic!("failed to execute CTAP2 command: {err:?}"),
                     }
                 }

--- a/libwebauthn-tests/src/virt/pipe.rs
+++ b/libwebauthn-tests/src/virt/pipe.rs
@@ -234,7 +234,7 @@ impl<'a, const N: usize> Pipe<'a, N> {
     }
 
     fn start_sending_error_on_channel(&mut self, channel: u32, error: CtapError) {
-        self.buffer[0] = error as u8;
+        self.buffer[0] = u8::from(error);
         let response = Response::error_on_channel(channel);
         self.start_sending(response);
     }
@@ -243,7 +243,7 @@ impl<'a, const N: usize> Pipe<'a, N> {
         let last_state = core::mem::replace(&mut self.state, State::Idle);
         let last_first_byte = self.buffer[0];
 
-        self.buffer[0] = error as u8;
+        self.buffer[0] = u8::from(error);
         let response = Response::error_from_request(request);
         self.start_sending(response);
         self.maybe_write_packet();

--- a/libwebauthn/src/proto/ctap2/cbor/response.rs
+++ b/libwebauthn/src/proto/ctap2/cbor/response.rs
@@ -1,8 +1,7 @@
 use crate::proto::error::CtapError;
 
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::io::{Error as IOError, ErrorKind as IOErrorKind};
-use tracing::error;
 
 #[derive(Debug, Clone)]
 pub struct CborResponse {
@@ -32,13 +31,7 @@ impl TryFrom<&Vec<u8>> for CborResponse {
             )
         })?;
 
-        let Ok(status_code) = (*status_byte).try_into() else {
-            error!({ code = ?*status_byte }, "Invalid CTAP error code");
-            return Err(IOError::new(
-                IOErrorKind::InvalidData,
-                format!("Invalid CTAP error code: {:x}", status_byte),
-            ));
-        };
+        let status_code = CtapError::from(*status_byte);
 
         let data = if body.is_empty() {
             None
@@ -46,5 +39,27 @@ impl TryFrom<&Vec<u8>> for CborResponse {
             Some(Vec::from(body))
         };
         Ok(CborResponse { status_code, data })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CborResponse;
+    use crate::proto::error::CtapError;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn unknown_status_byte_is_preserved() {
+        let response = CborResponse::try_from(&vec![0xDEu8]).expect("must not be a framing error");
+        assert_eq!(response.status_code, CtapError::Unknown(0xDE));
+        assert!(response.data.is_none());
+    }
+
+    #[test]
+    fn unknown_status_byte_keeps_body() {
+        let response =
+            CborResponse::try_from(&vec![0xF5u8, 0xAA, 0xBB]).expect("must not be a framing error");
+        assert_eq!(response.status_code, CtapError::Unknown(0xF5));
+        assert_eq!(response.data.as_deref(), Some(&[0xAA, 0xBB][..]));
     }
 }

--- a/libwebauthn/src/proto/error.rs
+++ b/libwebauthn/src/proto/error.rs
@@ -1,59 +1,60 @@
-use num_enum::{IntoPrimitive, TryFromPrimitive};
-
 use crate::proto::ctap1::apdu::ApduResponseStatus;
 
 // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#error-responses
 
-#[derive(Debug, IntoPrimitive, TryFromPrimitive, Copy, Clone, PartialEq)]
-#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum CtapError {
-    Ok = 0x00,                     // CTAP1_ERR_SUCCESS, CTAP2_OK
-    InvalidCommand = 0x01,         // CTAP1_ERR_INVALID_COMMAND
-    InvalidParameter = 0x02,       // CTAP1_ERR_INVALID_PARAMETER
-    InvalidLength = 0x03,          // CTAP1_ERR_INVALID_LENGTH
-    InvalidSeq = 0x04,             // CTAP1_ERR_INVALID_SEQ
-    Timeout = 0x05,                // CTAP1_ERR_TIMEOUT
-    ChannelBusy = 0x06,            // CTAP1_ERR_CHANNEL_BUSY
-    LockRequired = 0x0A,           // CTAP1_ERR_LOCK_REQUIRED
-    InvalidChannel = 0x0B,         // CTAP1_ERR_INVALID_CHANNEL
-    InvalidCborType = 0x11,        // CTAP2_ERR_CBOR_UNEXPECTED_TYPE
-    InvalidCbor = 0x12,            // CTAP2_ERR_INVALID_CBOR
-    MissingParameter = 0x14,       // CTAP2_ERR_MISSING_PARAMETER
-    LimitExceeded = 0x15,          // CTAP2_ERR_LIMIT_EXCEEDED,
-    UnsupportedExtension = 0x16,   // CTAP2_ERR_UNSUPPORTED_EXTENSION
-    CredentialExcluded = 0x19,     // CTAP2_ERR_CREDENTIAL_EXCLUDED
-    Processing = 0x21,             // CTAP2_ERR_PROCESSING
-    InvalidCredential = 0x22,      // CTAP2_ERR_INVALID_CREDENTIAL
-    UserActionPending = 0x23,      // CTAP2_ERR_USER_ACTION_PENDING
-    OperationPending = 0x24,       // CTAP2_ERR_OPERATION_PENDING
-    NoOperations = 0x25,           // CTAP2_ERR_NO_OPERATIONS
-    UnsupportedAlgorithm = 0x26,   // CTAP2_ERR_UNSUPPORTED_ALGORITHM
-    OperationDenied = 0x27,        // CTAP2_ERR_OPERATION_DENIED
-    KeyStoreFull = 0x28,           // CTAP2_ERR_KEY_STORE_FULL
-    NoOperationPending = 0x2A,     // CTAP2_ERR_NO_OPERATION_PENDING
-    UnsupportedOption = 0x2B,      // CTAP2_ERR_UNSUPPORTED_OPTION
-    InvalidOption = 0x2C,          // CTAP2_ERR_INVALID_OPTION
-    KeepAliveCancel = 0x2D,        // CTAP2_ERR_KEEPALIVE_CANCEL
-    NoCredentials = 0x2E,          // CTAP2_ERR_NO_CREDENTIALS
-    UserActionTimeout = 0x2F,      // CTAP2_ERR_USER_ACTION_TIMEOUT
-    NotAllowed = 0x30,             // CTAP2_ERR_NOT_ALLOWED
-    PINInvalid = 0x31,             // CTAP2_ERR_PIN_INVALID
-    PINBlocked = 0x32,             // CTAP2_ERR_PIN_BLOCKED
-    PINAuthInvalid = 0x33,         // CTAP2_ERR_PIN_AUTH_INVALID
-    PINAuthBlocked = 0x34,         // CTAP2_ERR_PIN_AUTH_BLOCKED
-    PINNotSet = 0x35,              // CTAP2_ERR_PIN_NOT_SET
-    PINRequired = 0x36,            // CTAP2_ERR_PIN_REQUIRED
-    PINPolicyViolation = 0x37,     // CTAP2_ERR_PIN_POLICY_VIOLATION
-    PINTokenExpired = 0x38,        // CTAP2_ERR_PIN_TOKEN_EXPIRED
-    RequestTooLarge = 0x39,        // CTAP2_ERR_REQUEST_TOO_LARGE
-    ActionTimeout = 0x3A,          // CTAP2_ERR_ACTION_TIMEOUT
-    UserPresenceRequired = 0x3B,   // CTAP2_ERR_UP_REQUIRED
-    UvBlocked = 0x3C,              // CTAP2_ERR_UV_BLOCKED
-    IntegrityFailure = 0x3D,       // CTAP2_ERR_INTEGRITY_FAILURE
-    InvalidSubcommand = 0x3E,      // CTAP2_ERR_INVALID_SUBCOMMAND
-    UVInvalid = 0x3F,              // CTAP2_ERR_UV_INVALID
-    UnauthorizedPermission = 0x40, // CTAP2_ERR_UNAUTHORIZED_PERMISSION
-    Other = 0x7F,                  // CTAP1_ERR_OTHER
+    Ok,                     // CTAP1_ERR_SUCCESS, CTAP2_OK
+    InvalidCommand,         // CTAP1_ERR_INVALID_COMMAND
+    InvalidParameter,       // CTAP1_ERR_INVALID_PARAMETER
+    InvalidLength,          // CTAP1_ERR_INVALID_LENGTH
+    InvalidSeq,             // CTAP1_ERR_INVALID_SEQ
+    Timeout,                // CTAP1_ERR_TIMEOUT
+    ChannelBusy,            // CTAP1_ERR_CHANNEL_BUSY
+    LockRequired,           // CTAP1_ERR_LOCK_REQUIRED
+    InvalidChannel,         // CTAP1_ERR_INVALID_CHANNEL
+    InvalidCborType,        // CTAP2_ERR_CBOR_UNEXPECTED_TYPE
+    InvalidCbor,            // CTAP2_ERR_INVALID_CBOR
+    MissingParameter,       // CTAP2_ERR_MISSING_PARAMETER
+    LimitExceeded,          // CTAP2_ERR_LIMIT_EXCEEDED
+    UnsupportedExtension,   // CTAP2_ERR_UNSUPPORTED_EXTENSION
+    FpDatabaseFull,         // CTAP2_ERR_FP_DATABASE_FULL
+    LargeBlobStorageFull,   // CTAP2_ERR_LARGE_BLOB_STORAGE_FULL
+    CredentialExcluded,     // CTAP2_ERR_CREDENTIAL_EXCLUDED
+    Processing,             // CTAP2_ERR_PROCESSING
+    InvalidCredential,      // CTAP2_ERR_INVALID_CREDENTIAL
+    UserActionPending,      // CTAP2_ERR_USER_ACTION_PENDING
+    OperationPending,       // CTAP2_ERR_OPERATION_PENDING
+    NoOperations,           // CTAP2_ERR_NO_OPERATIONS
+    UnsupportedAlgorithm,   // CTAP2_ERR_UNSUPPORTED_ALGORITHM
+    OperationDenied,        // CTAP2_ERR_OPERATION_DENIED
+    KeyStoreFull,           // CTAP2_ERR_KEY_STORE_FULL
+    NoOperationPending,     // CTAP2_ERR_NO_OPERATION_PENDING
+    UnsupportedOption,      // CTAP2_ERR_UNSUPPORTED_OPTION
+    InvalidOption,          // CTAP2_ERR_INVALID_OPTION
+    KeepAliveCancel,        // CTAP2_ERR_KEEPALIVE_CANCEL
+    NoCredentials,          // CTAP2_ERR_NO_CREDENTIALS
+    UserActionTimeout,      // CTAP2_ERR_USER_ACTION_TIMEOUT
+    NotAllowed,             // CTAP2_ERR_NOT_ALLOWED
+    PINInvalid,             // CTAP2_ERR_PIN_INVALID
+    PINBlocked,             // CTAP2_ERR_PIN_BLOCKED
+    PINAuthInvalid,         // CTAP2_ERR_PIN_AUTH_INVALID
+    PINAuthBlocked,         // CTAP2_ERR_PIN_AUTH_BLOCKED
+    PINNotSet,              // CTAP2_ERR_PIN_NOT_SET
+    PINRequired,            // CTAP2_ERR_PIN_REQUIRED
+    PINPolicyViolation,     // CTAP2_ERR_PIN_POLICY_VIOLATION
+    PINTokenExpired,        // CTAP2_ERR_PIN_TOKEN_EXPIRED
+    RequestTooLarge,        // CTAP2_ERR_REQUEST_TOO_LARGE
+    ActionTimeout,          // CTAP2_ERR_ACTION_TIMEOUT
+    UserPresenceRequired,   // CTAP2_ERR_UP_REQUIRED
+    UvBlocked,              // CTAP2_ERR_UV_BLOCKED
+    IntegrityFailure,       // CTAP2_ERR_INTEGRITY_FAILURE
+    InvalidSubcommand,      // CTAP2_ERR_INVALID_SUBCOMMAND
+    UVInvalid,              // CTAP2_ERR_UV_INVALID
+    UnauthorizedPermission, // CTAP2_ERR_UNAUTHORIZED_PERMISSION
+    Other,                  // CTAP1_ERR_OTHER
+    // Unmapped, vendor-specific (0xF0-0xFF), and reserved codes are preserved verbatim.
+    Unknown(u8),
 }
 
 impl CtapError {
@@ -64,18 +65,139 @@ impl CtapError {
             _ => false,
         }
     }
+
+    pub fn is_known(&self) -> bool {
+        !matches!(self, Self::Unknown(_))
+    }
+}
+
+impl From<u8> for CtapError {
+    fn from(byte: u8) -> Self {
+        match byte {
+            0x00 => Self::Ok,
+            0x01 => Self::InvalidCommand,
+            0x02 => Self::InvalidParameter,
+            0x03 => Self::InvalidLength,
+            0x04 => Self::InvalidSeq,
+            0x05 => Self::Timeout,
+            0x06 => Self::ChannelBusy,
+            0x0A => Self::LockRequired,
+            0x0B => Self::InvalidChannel,
+            0x11 => Self::InvalidCborType,
+            0x12 => Self::InvalidCbor,
+            0x14 => Self::MissingParameter,
+            0x15 => Self::LimitExceeded,
+            0x16 => Self::UnsupportedExtension,
+            0x17 => Self::FpDatabaseFull,
+            0x18 => Self::LargeBlobStorageFull,
+            0x19 => Self::CredentialExcluded,
+            0x21 => Self::Processing,
+            0x22 => Self::InvalidCredential,
+            0x23 => Self::UserActionPending,
+            0x24 => Self::OperationPending,
+            0x25 => Self::NoOperations,
+            0x26 => Self::UnsupportedAlgorithm,
+            0x27 => Self::OperationDenied,
+            0x28 => Self::KeyStoreFull,
+            0x2A => Self::NoOperationPending,
+            0x2B => Self::UnsupportedOption,
+            0x2C => Self::InvalidOption,
+            0x2D => Self::KeepAliveCancel,
+            0x2E => Self::NoCredentials,
+            0x2F => Self::UserActionTimeout,
+            0x30 => Self::NotAllowed,
+            0x31 => Self::PINInvalid,
+            0x32 => Self::PINBlocked,
+            0x33 => Self::PINAuthInvalid,
+            0x34 => Self::PINAuthBlocked,
+            0x35 => Self::PINNotSet,
+            0x36 => Self::PINRequired,
+            0x37 => Self::PINPolicyViolation,
+            0x38 => Self::PINTokenExpired,
+            0x39 => Self::RequestTooLarge,
+            0x3A => Self::ActionTimeout,
+            0x3B => Self::UserPresenceRequired,
+            0x3C => Self::UvBlocked,
+            0x3D => Self::IntegrityFailure,
+            0x3E => Self::InvalidSubcommand,
+            0x3F => Self::UVInvalid,
+            0x40 => Self::UnauthorizedPermission,
+            0x7F => Self::Other,
+            other => Self::Unknown(other),
+        }
+    }
+}
+
+impl From<CtapError> for u8 {
+    fn from(error: CtapError) -> Self {
+        match error {
+            CtapError::Ok => 0x00,
+            CtapError::InvalidCommand => 0x01,
+            CtapError::InvalidParameter => 0x02,
+            CtapError::InvalidLength => 0x03,
+            CtapError::InvalidSeq => 0x04,
+            CtapError::Timeout => 0x05,
+            CtapError::ChannelBusy => 0x06,
+            CtapError::LockRequired => 0x0A,
+            CtapError::InvalidChannel => 0x0B,
+            CtapError::InvalidCborType => 0x11,
+            CtapError::InvalidCbor => 0x12,
+            CtapError::MissingParameter => 0x14,
+            CtapError::LimitExceeded => 0x15,
+            CtapError::UnsupportedExtension => 0x16,
+            CtapError::FpDatabaseFull => 0x17,
+            CtapError::LargeBlobStorageFull => 0x18,
+            CtapError::CredentialExcluded => 0x19,
+            CtapError::Processing => 0x21,
+            CtapError::InvalidCredential => 0x22,
+            CtapError::UserActionPending => 0x23,
+            CtapError::OperationPending => 0x24,
+            CtapError::NoOperations => 0x25,
+            CtapError::UnsupportedAlgorithm => 0x26,
+            CtapError::OperationDenied => 0x27,
+            CtapError::KeyStoreFull => 0x28,
+            CtapError::NoOperationPending => 0x2A,
+            CtapError::UnsupportedOption => 0x2B,
+            CtapError::InvalidOption => 0x2C,
+            CtapError::KeepAliveCancel => 0x2D,
+            CtapError::NoCredentials => 0x2E,
+            CtapError::UserActionTimeout => 0x2F,
+            CtapError::NotAllowed => 0x30,
+            CtapError::PINInvalid => 0x31,
+            CtapError::PINBlocked => 0x32,
+            CtapError::PINAuthInvalid => 0x33,
+            CtapError::PINAuthBlocked => 0x34,
+            CtapError::PINNotSet => 0x35,
+            CtapError::PINRequired => 0x36,
+            CtapError::PINPolicyViolation => 0x37,
+            CtapError::PINTokenExpired => 0x38,
+            CtapError::RequestTooLarge => 0x39,
+            CtapError::ActionTimeout => 0x3A,
+            CtapError::UserPresenceRequired => 0x3B,
+            CtapError::UvBlocked => 0x3C,
+            CtapError::IntegrityFailure => 0x3D,
+            CtapError::InvalidSubcommand => 0x3E,
+            CtapError::UVInvalid => 0x3F,
+            CtapError::UnauthorizedPermission => 0x40,
+            CtapError::Other => 0x7F,
+            CtapError::Unknown(byte) => byte,
+        }
+    }
 }
 
 impl std::error::Error for CtapError {}
 
 impl std::fmt::Display for CtapError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "{:?} (retryable user error: {})",
-            self,
-            self.is_retryable_user_error()
-        )
+        match self {
+            Self::Unknown(byte) => write!(f, "Unknown(0x{:02X})", byte),
+            _ => write!(
+                f,
+                "{:?} (retryable user error: {})",
+                self,
+                self.is_retryable_user_error()
+            ),
+        }
     }
 }
 
@@ -90,5 +212,38 @@ impl From<ApduResponseStatus> for CtapError {
             ApduResponseStatus::InvalidClassByte => CtapError::Other,
             ApduResponseStatus::InvalidInstruction => CtapError::InvalidCommand,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CtapError;
+
+    #[test]
+    fn all_bytes_round_trip() {
+        for byte in 0u8..=0xFF {
+            let error = CtapError::from(byte);
+            assert_eq!(u8::from(error), byte, "round-trip failed for 0x{byte:02X}");
+        }
+    }
+
+    #[test]
+    fn named_ctap22_codes() {
+        assert_eq!(CtapError::from(0x17), CtapError::FpDatabaseFull);
+        assert_eq!(CtapError::from(0x18), CtapError::LargeBlobStorageFull);
+    }
+
+    #[test]
+    fn unknown_codes_preserved() {
+        assert_eq!(CtapError::from(0xDE), CtapError::Unknown(0xDE));
+        assert_eq!(CtapError::from(0x07), CtapError::Unknown(0x07));
+        assert_eq!(CtapError::from(0xF5), CtapError::Unknown(0xF5));
+        assert!(!CtapError::from(0xF5).is_known());
+        assert!(CtapError::from(0x17).is_known());
+    }
+
+    #[test]
+    fn unknown_displays_as_hex() {
+        assert_eq!(CtapError::Unknown(0xAB).to_string(), "Unknown(0xAB)");
     }
 }


### PR DESCRIPTION
Unknown and vendor CTAP status codes were reported as wire framing errors, which masked the real device response. The client now preserves any unrecognized status byte and surfaces it to the caller, and it adds the two defined codes for a full fingerprint store and a full large-blob store. Error reporting for real device conditions is now accurate instead of looking like corruption.