### PR TITLE
fix(ctap2): tolerate unknown authenticator transports in descriptors

### DIFF
--- a/libwebauthn/src/ops/webauthn/get_assertion.rs
+++ b/libwebauthn/src/ops/webauthn/get_assertion.rs
@@ -839,6 +839,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_request_from_json_passes_through_unknown_transports() {
+        use crate::proto::ctap2::Ctap2Transport;
+
+        let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
+        let req_json = json_field_add(
+            REQUEST_BASE_JSON,
+            "allowCredentials",
+            r#"[{"type":"public-key","id":"bXktY3JlZGVudGlhbC1pZA","transports":["usb","smart-card","future-transport"]}]"#,
+        );
+
+        let req: GetAssertionRequest = from_json(
+            &request_origin,
+            &MockPublicSuffixList,
+            RelatedOrigins::Disabled,
+            &req_json,
+        )
+        .await
+        .unwrap();
+
+        let transports = req.allow[0]
+            .transports
+            .as_ref()
+            .expect("transports preserved");
+        assert_eq!(
+            transports,
+            &vec![
+                Ctap2Transport::Usb,
+                Ctap2Transport::SmartCard,
+                Ctap2Transport::Other("future-transport".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn test_request_from_json_ignore_missing_rp_id() {
         let request_origin: RequestOrigin = "https://example.org".parse().unwrap();
         let req_json = json_field_rm(REQUEST_BASE_JSON, "rpId");

--- a/libwebauthn/src/proto/ctap1/model.rs
+++ b/libwebauthn/src/proto/ctap1/model.rs
@@ -25,8 +25,7 @@ impl TryFrom<&Ctap2Transport> for Ctap1Transport {
             Ctap2Transport::Ble => Ok(Ctap1Transport::Ble),
             Ctap2Transport::Usb => Ok(Ctap1Transport::Usb),
             Ctap2Transport::Nfc => Ok(Ctap1Transport::Nfc),
-            Ctap2Transport::Internal => Err(CtapError::UnsupportedOption),
-            Ctap2Transport::Hybrid => Err(CtapError::UnsupportedOption),
+            _ => Err(CtapError::UnsupportedOption),
         }
     }
 }
@@ -352,5 +351,43 @@ mod tests {
         assert_eq!(decoded.key_handle, hex::decode("602CFD267868E84D4852BD5B008BC6CE0211D4858C8A647328A13B7D5C0A42B3893D63A58FCA7BD3EBB74F55CE537195DFF0113D4C561BBB7DFAC0C0ECD1AFB5").unwrap());
         assert_eq!(decoded.attestation, hex::decode("3082015930820100A003020102020102300A06082A8648CE3D0403023028311530130603550403130C5365637572697479204B6579310F300D060355040A1306476F6F676C653022180F32303030303130313030303030305A180F32303939313233313233353935395A3028311530130603550403130C5365637572697479204B6579310F300D060355040A1306476F6F676C653059301306072A8648CE3D020106082A8648CE3D030107034200040393AF897BE858E88C1953876A1A538477C4DA6E6EA14ACF0A2FD89A4DCCF95878A8CD2929029CC1D794BFFB9C37547CBBB5BB31AB3A6756ACF74F123CECD45CA31730153013060B2B0601040182E51C020101040403020470300A06082A8648CE3D040302034700304402207F958ABE6CF08CB2E9A03774D52DF8C0EA261E1AC0C283409FEDD8D36DFAF09302204EEB7501C720428D206E1B092D8D26CA8536B70F5F09AEA99562390BEF1BA7EC").unwrap());
         assert_eq!(decoded.signature, hex::decode("3044022031413D6E238A5F998B26B3931655C411847D99776B6E5CF15AA2E11BFAF325F00220098745DA82C11BB242934BAC6AE95155EAAD68520D695D46982DA9B2C94F94E3").unwrap());
+    }
+
+    #[test]
+    fn known_ctap2_transports_downgrade_to_ctap1() {
+        use crate::proto::ctap1::Ctap1Transport;
+        use crate::proto::ctap2::Ctap2Transport;
+
+        assert!(matches!(
+            Ctap1Transport::try_from(&Ctap2Transport::Usb),
+            Ok(Ctap1Transport::Usb)
+        ));
+        assert!(matches!(
+            Ctap1Transport::try_from(&Ctap2Transport::Ble),
+            Ok(Ctap1Transport::Ble)
+        ));
+        assert!(matches!(
+            Ctap1Transport::try_from(&Ctap2Transport::Nfc),
+            Ok(Ctap1Transport::Nfc)
+        ));
+    }
+
+    #[test]
+    fn unsupported_ctap2_transports_fail_to_downgrade() {
+        use crate::proto::ctap1::Ctap1Transport;
+        use crate::proto::ctap2::Ctap2Transport;
+        use crate::webauthn::CtapError;
+
+        for transport in [
+            Ctap2Transport::Internal,
+            Ctap2Transport::Hybrid,
+            Ctap2Transport::SmartCard,
+            Ctap2Transport::Other("future-transport".to_string()),
+        ] {
+            assert!(matches!(
+                Ctap1Transport::try_from(&transport),
+                Err(CtapError::UnsupportedOption)
+            ));
+        }
     }
 }

--- a/libwebauthn/src/proto/ctap2/model.rs
+++ b/libwebauthn/src/proto/ctap2/model.rs
@@ -147,14 +147,54 @@ pub enum Ctap2PublicKeyCredentialType {
     Unknown,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+/// AuthenticatorTransport from a credential descriptor. Unknown values are kept in `Other` so they pass through unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
 pub enum Ctap2Transport {
     Ble,
     Nfc,
     Usb,
     Internal,
     Hybrid,
+    SmartCard,
+    Other(String),
+}
+
+impl Ctap2Transport {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Ble => "ble",
+            Self::Nfc => "nfc",
+            Self::Usb => "usb",
+            Self::Internal => "internal",
+            Self::Hybrid => "hybrid",
+            Self::SmartCard => "smart-card",
+            Self::Other(value) => value,
+        }
+    }
+}
+
+impl From<String> for Ctap2Transport {
+    fn from(value: String) -> Self {
+        match value.as_str() {
+            "ble" => Self::Ble,
+            "nfc" => Self::Nfc,
+            "usb" => Self::Usb,
+            "internal" => Self::Internal,
+            "hybrid" => Self::Hybrid,
+            "smart-card" => Self::SmartCard,
+            _ => Self::Other(value),
+        }
+    }
+}
+
+impl From<Ctap2Transport> for String {
+    fn from(transport: Ctap2Transport) -> Self {
+        match transport {
+            Ctap2Transport::Other(value) => value,
+            known => known.as_str().to_owned(),
+        }
+    }
 }
 
 impl From<&Ctap1Transport> for Ctap2Transport {
@@ -506,5 +546,20 @@ mod tests {
             Ctap2COSEAlgorithmIdentifier(-9)
         );
         assert!(Ctap2COSEAlgorithmIdentifier::ESP256.is_known());
+    }
+
+    #[test]
+    fn unrecognised_transport_roundtrips_through_cbor() {
+        let value = Ctap2Transport::Other("future-transport".to_string());
+        let encoded = serde_cbor::to_vec(&value).unwrap();
+        let decoded: Ctap2Transport = serde_cbor::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn smart_card_transport_roundtrips_through_cbor() {
+        let encoded = serde_cbor::to_vec(&Ctap2Transport::SmartCard).unwrap();
+        let decoded: Ctap2Transport = serde_cbor::from_slice(&encoded).unwrap();
+        assert_eq!(decoded, Ctap2Transport::SmartCard);
     }
 }


### PR DESCRIPTION
Parsing a credential descriptor that listed an unrecognized transport value failed the whole request. Unknown transport values are now ignored, as the spec requires, so a forward-compatible relying party request still succeeds. Recognized transports are handled as before.