### PR TITLE
fix(authnr-config): gate config subcommands on getInfo capabilities

### DIFF
--- a/libwebauthn/src/management/authenticator_config.rs
+++ b/libwebauthn/src/management/authenticator_config.rs
@@ -1,7 +1,7 @@
 use crate::proto::ctap2::cbor;
 use crate::proto::ctap2::Ctap2ClientPinRequest;
 use crate::transport::Channel;
-pub use crate::webauthn::error::{CtapError, Error};
+pub use crate::webauthn::error::{CtapError, Error, PlatformError};
 use crate::webauthn::handle_errors;
 use crate::webauthn::pin_uv_auth_token::{user_verification, UsedPinUvAuthToken};
 use crate::{
@@ -45,6 +45,12 @@ where
     C: Channel,
 {
     async fn toggle_always_uv(&mut self, timeout: Duration) -> Result<(), Error> {
+        let info = self.ctap2_get_info().await?;
+        // CTAP 2.1 6.2.5: toggleAlwaysUv is gated on the alwaysUv option only.
+        if !info.option_enabled("authnrCfg") || !info.option_exists("alwaysUv") {
+            return Err(Error::Platform(PlatformError::NotSupported));
+        }
+
         let mut req = Ctap2AuthenticatorConfigRequest::new_toggle_always_uv();
 
         loop {
@@ -66,6 +72,11 @@ where
     }
 
     async fn enable_enterprise_attestation(&mut self, timeout: Duration) -> Result<(), Error> {
+        let info = self.ctap2_get_info().await?;
+        if !info.option_enabled("authnrCfg") || !info.option_exists("ep") {
+            return Err(Error::Platform(PlatformError::NotSupported));
+        }
+
         let mut req = Ctap2AuthenticatorConfigRequest::new_enable_enterprise_attestation();
 
         loop {
@@ -91,6 +102,11 @@ where
         new_pin_length: u64,
         timeout: Duration,
     ) -> Result<(), Error> {
+        let info = self.ctap2_get_info().await?;
+        if !info.option_enabled("authnrCfg") || !info.option_exists("setMinPINLength") {
+            return Err(Error::Platform(PlatformError::NotSupported));
+        }
+
         let mut req = Ctap2AuthenticatorConfigRequest::new_set_min_pin_length(new_pin_length);
 
         loop {
@@ -112,6 +128,11 @@ where
     }
 
     async fn force_change_pin(&mut self, force: bool, timeout: Duration) -> Result<(), Error> {
+        let info = self.ctap2_get_info().await?;
+        if !info.option_enabled("authnrCfg") || !info.option_exists("setMinPINLength") {
+            return Err(Error::Platform(PlatformError::NotSupported));
+        }
+
         let mut req = Ctap2AuthenticatorConfigRequest::new_force_change_pin(force);
 
         loop {
@@ -137,6 +158,18 @@ where
         rpids: Vec<String>,
         timeout: Duration,
     ) -> Result<(), Error> {
+        let info = self.ctap2_get_info().await?;
+        if !info.option_enabled("authnrCfg")
+            || !info.option_exists("setMinPINLength")
+            || !info.supports_extension("minPinLength")
+        {
+            return Err(Error::Platform(PlatformError::NotSupported));
+        }
+        let max_rpids = u64::from(info.max_rpids_for_setminpinlength.unwrap_or(u32::MAX));
+        if rpids.len() as u64 > max_rpids {
+            return Err(Error::Platform(PlatformError::RequestTooLarge));
+        }
+
         let mut req = Ctap2AuthenticatorConfigRequest::new_set_min_pin_length_rpids(rpids);
         loop {
             let uv_auth_used = user_verification(
@@ -199,5 +232,95 @@ impl Ctap2UserVerifiableRequest for Ctap2AuthenticatorConfigRequest {
 
     fn needs_shared_secret(&self, _get_info_response: &Ctap2GetInfoResponse) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    use super::{AuthenticatorConfig, Error, PlatformError};
+    use crate::proto::ctap2::cbor::{self, CborRequest, CborResponse};
+    use crate::proto::ctap2::{Ctap2CommandCode, Ctap2GetInfoResponse};
+    use crate::transport::mock::channel::MockChannel;
+
+    const TIMEOUT: Duration = Duration::from_secs(1);
+
+    fn push_get_info(channel: &mut MockChannel, info: &Ctap2GetInfoResponse) {
+        let req = CborRequest::new(Ctap2CommandCode::AuthenticatorGetInfo);
+        let resp = CborResponse::new_success_from_slice(&cbor::to_vec(info).unwrap());
+        channel.push_command_pair(req, resp);
+    }
+
+    #[tokio::test]
+    async fn toggle_always_uv_rejected_when_authnr_cfg_absent() {
+        let mut channel = MockChannel::new();
+        push_get_info(
+            &mut channel,
+            &Ctap2GetInfoResponse {
+                options: Some(HashMap::from([("alwaysUv".to_string(), false)])),
+                ..Default::default()
+            },
+        );
+
+        let result = channel.toggle_always_uv(TIMEOUT).await;
+        assert_eq!(result, Err(Error::Platform(PlatformError::NotSupported)));
+    }
+
+    #[tokio::test]
+    async fn toggle_always_uv_rejected_when_always_uv_option_absent() {
+        let mut channel = MockChannel::new();
+        push_get_info(
+            &mut channel,
+            &Ctap2GetInfoResponse {
+                options: Some(HashMap::from([("authnrCfg".to_string(), true)])),
+                ..Default::default()
+            },
+        );
+
+        let result = channel.toggle_always_uv(TIMEOUT).await;
+        assert_eq!(result, Err(Error::Platform(PlatformError::NotSupported)));
+    }
+
+    #[tokio::test]
+    async fn set_min_pin_length_rpids_rejected_when_extension_absent() {
+        let mut channel = MockChannel::new();
+        push_get_info(
+            &mut channel,
+            &Ctap2GetInfoResponse {
+                options: Some(HashMap::from([
+                    ("authnrCfg".to_string(), true),
+                    ("setMinPINLength".to_string(), true),
+                ])),
+                ..Default::default()
+            },
+        );
+
+        let result = channel
+            .set_min_pin_length_rpids(vec!["example.com".to_string()], TIMEOUT)
+            .await;
+        assert_eq!(result, Err(Error::Platform(PlatformError::NotSupported)));
+    }
+
+    #[tokio::test]
+    async fn set_min_pin_length_rpids_rejected_when_too_many_rpids() {
+        let mut channel = MockChannel::new();
+        push_get_info(
+            &mut channel,
+            &Ctap2GetInfoResponse {
+                options: Some(HashMap::from([
+                    ("authnrCfg".to_string(), true),
+                    ("setMinPINLength".to_string(), true),
+                ])),
+                extensions: Some(vec!["minPinLength".to_string()]),
+                max_rpids_for_setminpinlength: Some(1),
+                ..Default::default()
+            },
+        );
+
+        let rpids = vec!["example.com".to_string(), "example.org".to_string()];
+        let result = channel.set_min_pin_length_rpids(rpids, TIMEOUT).await;
+        assert_eq!(result, Err(Error::Platform(PlatformError::RequestTooLarge)));
     }
 }


### PR DESCRIPTION
Authenticator configuration subcommands were sent without first confirming the device advertises support, and the minimum PIN length RP list was sent without a bound. Each subcommand now checks the relevant getInfo capability before being sent, and the RP list is bounded to the device limit. This avoids predictable rejections and respects the authenticator declared limits.