### PR TITLE
chore(ci): declare and gate msrv at 1.88

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,3 +35,19 @@ jobs:
           LIBWEBAUTHN_PSL_SYSTEM_TEST: "1"
       - name: Verify libwebauthn publishes cleanly
         run: cargo publish --dry-run -p libwebauthn
+
+  msrv:
+    name: Verify MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+      - name: Update apt cache
+        run: sudo apt-get update
+      - name: Install system dependencies
+        run: sudo apt-get install libudev-dev libdbus-1-dev libsodium-dev libnfc-dev libpcsclite-dev publicsuffix
+      - name: Install declared MSRV toolchain
+        run: rustup toolchain install 1.88 --profile minimal
+      - name: Check against declared MSRV
+        run: cargo +1.88 check --workspace --all-features

--- a/libwebauthn-tests/Cargo.toml
+++ b/libwebauthn-tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "libwebauthn-tests"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.88"
 publish = false
 license-file = "../COPYING"
 

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
     "Isaiah Inuwa <isaiah.inuwa@gmail.com>",
 ]
 edition = "2021"
+rust-version = "1.88"
 license = "LGPL-2.1-or-later"
 license-file = "../COPYING"
 readme = "../README.md"


### PR DESCRIPTION
Declares a minimum supported Rust version and verifies it in CI, so the crate makes an explicit toolchain commitment ahead of a stable release. The value was derived from the current dependency tree and can be relaxed if we want broader compatibility.