### PR TITLE
chore(ci): pin build job to rust 1.96.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,13 @@ jobs:
         run: sudo apt-get update
       - name: Install system dependencies
         run: sudo apt-get install libudev-dev libdbus-1-dev libsodium-dev libnfc-dev libpcsclite-dev publicsuffix
+      - name: Install pinned toolchain
+        # Drop the toolchain the image ships with once we have switched off it. The job builds the
+        # workspace three times over, and the runner does not have the disk to spare for both.
+        run: |
+          rustup toolchain install 1.96.1 --profile minimal -c clippy,rustfmt
+          rustup default 1.96.1
+          rustup toolchain uninstall stable
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Check formatting


### PR DESCRIPTION
Our build job doesn't install a toolchain, so it runs on whatever Rust the runner image happens to ship. Clippy is gated with -D warnings, so the day that image moves to a newer compiler, master and every open PR go red at once.

Pin the job to 1.96.1, which is green today. CI config only, no code changes.
