### PR TITLE
chore(nfc): Bump nfc1 to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,9 +2252,9 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "nfc1"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d6dc2e4110af159c220d2d004661e380b6c40d93c5b04e839e4944f9d5291d"
+checksum = "86cab229f42df4140bb410c1d2cd2f9008b22575742719cfc73268fb6308bab8"
 dependencies = [
  "nfc1-sys",
 ]

--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -108,7 +108,7 @@ serde_json = "1.0.141"
 apdu-core = { version = "0.4.0", optional = true }
 apdu = { version = "0.4.0", optional = true }
 pcsc = { version = "2.9.0", optional = true }
-nfc1 = { version = "=0.6.0", optional = true, default-features = false }
+nfc1 = { version = "0.7.1", optional = true, default-features = false }
 nfc1-sys = { version = "0.3.9", optional = true, default-features = false }
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls-native-roots",

--- a/libwebauthn/src/transport/nfc/libnfc/mod.rs
+++ b/libwebauthn/src/transport/nfc/libnfc/mod.rs
@@ -66,7 +66,7 @@ unsafe impl Send for Channel {}
 
 impl Channel {
     pub fn new(info: &Info, mut context: nfc1::Context) -> Result<Self, NfcError> {
-        let mut device = context.open_with_connstring(&info.connstring)?;
+        let device = context.open_with_connstring(&info.connstring)?;
         let name = device.name().to_owned();
 
         Ok(Self {


### PR DESCRIPTION
This was previously pinned to 0.6.0 because of build issues for non-vendored build in 0.6.1. 0.7.1 has been release which fixes that issue, so we're removing the pin to let consumers resolve their own version.