### PR TITLE
Mark WebAuthnError as deprecated.

### DIFF
--- a/libwebauthn/src/webauthn/error.rs
+++ b/libwebauthn/src/webauthn/error.rs
@@ -16,6 +16,7 @@ pub enum Error<E> {
     Platform(#[source] PlatformError),
 }
 
+#[deprecated(note = "Use `Error` instead")]
 /// Former name of the ceremony [`Error`], retained to avoid call-site churn.
 pub use self::Error as WebAuthnError;
 


### PR DESCRIPTION
This hopefully slowly gets more call-sites to switch from WebAuthnError to Error.