### PR TITLE
Remove duplicate license specification

### DIFF
--- a/libwebauthn/Cargo.toml
+++ b/libwebauthn/Cargo.toml
@@ -9,7 +9,6 @@ authors = [
 ]
 edition = "2021"
 rust-version = "1.88"
-license = "LGPL-2.1-or-later"
 license-file = "../COPYING"
 readme = "../README.md"
 homepage = "https://github.com/linux-credentials"


### PR DESCRIPTION
Specifying both license and license-file is invalid. license-file seems the more concise option of the two.